### PR TITLE
allowing providing secrets to hephaestus to pass to builds

### DIFF
--- a/deployments/helm/hephaestus/templates/controller/deployment.yaml
+++ b/deployments/helm/hephaestus/templates/controller/deployment.yaml
@@ -77,6 +77,9 @@ spec:
             - name: log-vol
               mountPath: {{ include "hephaestus.logfileDir" . | quote }}
             {{- end }}
+            {{- with .Values.controller.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.logProcessor.enabled }}
         - name: log-processor
           securityContext:
@@ -112,6 +115,9 @@ spec:
         {{- if .Values.logProcessor.enabled }}
         - name: log-vol
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.controller.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/deployments/helm/hephaestus/templates/controller/secret.yaml
+++ b/deployments/helm/hephaestus/templates/controller/secret.yaml
@@ -23,6 +23,10 @@ stringData:
       {{- with .Values.controller.poolMaxIdleTime }}
       poolMaxIdleTime: {{ . | quote }}
       {{- end }}
+      {{- with .Values.controller.secrets }}
+      secrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.controller }}
     imageBuildMaxConcurrency: {{ .imageBuildMaxConcurrency }}
     manager:

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -88,6 +88,9 @@ controller:
   # Defaults to "10m"
   poolMaxIdleTime: null
 
+  # Secrets (name: path) to expose into builds that request it
+  secrets: {}
+
   # Resource requests and limits
   resources:
     requests: {}
@@ -126,6 +129,11 @@ controller:
 
   # Manager pods priorityClassName
   priorityClassName: ""
+
+  # Additional volume mounts
+  extraVolumeMounts: []
+  # Additional volumes
+  extraVolumes: []
 
   # Number of manager instances to run. Leader election will be enabled
   # whenever this value is greater than 1; this ensures that only one instance

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -42,7 +42,7 @@ func (b *clientBuilder) WithDockerAuthConfig(configDir string) *clientBuilder {
 func (b *clientBuilder) WithMTLSAuth(caPath, certPath, keyPath string) *clientBuilder {
 	u, err := url.Parse(b.addr)
 	if err != nil {
-		b.log.Error(err, "Cannot parse hostname, kipping mTLS auth", "addr", b.addr)
+		b.log.Error(err, "Cannot parse hostname, skipping mTLS auth", "addr", b.addr)
 	} else {
 		b.bkOpts = append(b.bkOpts, bkclient.WithCredentials(u.Hostname(), caPath, certPath, keyPath))
 	}
@@ -137,6 +137,8 @@ func (c *Client) Build(opts BuildOptions) error {
 		l.Info("Dockerfile contents:\n" + string(bs))
 	}
 
+	// Do not cache these as the file contents can change
+	// over time (e.g. when mounted from a configmap)
 	secrets := make(map[string][]byte)
 	for name, path := range opts.Secrets {
 		contents, err := os.ReadFile(path)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,8 @@ type Buildkit struct {
 	CertPath   string `json:"certPath" yaml:"certPath"`
 	KeyPath    string `json:"keyPath" yaml:"keyPath"`
 
+	Secrets map[string]string `json:"secrets" yaml:"secrets"`
+
 	PoolSyncWaitTime *time.Duration `json:"poolSyncWaitTime" yaml:"poolSyncWaitTime"`
 	PoolMaxIdleTime  *time.Duration `json:"poolMaxIdleTime" yaml:"poolMaxIdleTime"`
 }

--- a/pkg/controller/imagebuild/imagebuild.go
+++ b/pkg/controller/imagebuild/imagebuild.go
@@ -14,9 +14,13 @@ import (
 )
 
 func Register(mgr ctrl.Manager, cfg config.Controller, pool workerpool.Pool) error {
+	bd, err := component.BuildDispatcher(cfg.Buildkit, pool)
+	if err != nil {
+		return err
+	}
 	return core.NewReconciler(mgr).
 		For(&hephv1.ImageBuild{}).
-		Component("build-dispatcher", component.BuildDispatcher(cfg.Buildkit, pool)).
+		Component("build-dispatcher", bd).
 		WithControllerOptions(controller.Options{MaxConcurrentReconciles: cfg.ImageBuildMaxConcurrency}).
 		WithWebhooks().
 		Complete()

--- a/pkg/controller/imagebuild/imagebuild.go
+++ b/pkg/controller/imagebuild/imagebuild.go
@@ -14,13 +14,9 @@ import (
 )
 
 func Register(mgr ctrl.Manager, cfg config.Controller, pool workerpool.Pool) error {
-	bd, err := component.BuildDispatcher(cfg.Buildkit, pool)
-	if err != nil {
-		return err
-	}
 	return core.NewReconciler(mgr).
 		For(&hephv1.ImageBuild{}).
-		Component("build-dispatcher", bd).
+		Component("build-dispatcher", component.BuildDispatcher(cfg.Buildkit, pool)).
 		WithControllerOptions(controller.Options{MaxConcurrentReconciles: cfg.ImageBuildMaxConcurrency}).
 		WithWebhooks().
 		Complete()


### PR DESCRIPTION
e.g.

```yaml
controller:
  extraVolumes:
    - name: cert-vol
      configMap:
        name: domino-generated-certificates
  extraVolumeMounts:
    - name: cert-vol
      mountPath: /certs
  secrets:
    cacerts.p12: "/certs/cacerts.p12"
    ca-certificates.crt: "/certs/ca-certificates.crt"
```

and referencing them:
```dockerfile
FROM ...
RUN --mount=type=secret,required=true,target=/etc/ssl/certs/ca-certificates.crt,mode=444 \
  --mount=type=secret,required=true,target=/etc/ssl/certs/cacerts.p12,mode=444 \
  ls -la /etc/ssl/certs/
```