### PR TITLE
Cancel buildkitd Solve on ImageBuild delete

### DIFF
--- a/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
@@ -117,7 +117,7 @@ spec:
               transitions:
               - phase: Created
                 previousPhase: ""
-                processed: false
+                processed: true
             properties:
               buildTime:
                 description: BuildTime is the total time spend during the build process.

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -193,7 +193,7 @@ buildkit:
   image:
     registry: ""
     repository: moby/buildkit
-    tag: v0.10.2-rootless
+    tag: v0.10.3-rootless
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/docker/cli v20.10.13+incompatible
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/docker/docker v20.10.7+incompatible // master (v21.xx-dev), see replace()
-	github.com/dominodatalab/controller-util v0.0.0-20220428201130-ad497a3793c1
+	github.com/dominodatalab/controller-util v0.0.0-20220506190502-be6562838a47
 	github.com/go-logr/logr v1.2.2
 	github.com/go-logr/zapr v1.2.0
 	github.com/gofrs/flock v0.7.3
 	github.com/h2non/filetype v1.1.1
-	github.com/moby/buildkit v0.10.2
+	github.com/moby/buildkit v0.10.3
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.3.4
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dominodatalab/controller-util v0.0.0-20220428201130-ad497a3793c1 h1:IlRAhh81H++ODMZ5Cig3GwEqULQs0WQk+ymFLEFxfN4=
-github.com/dominodatalab/controller-util v0.0.0-20220428201130-ad497a3793c1/go.mod h1:Fp7RiFiZNfDJpijo2Nz4aQJ9483p+9OfwXzpNypllLA=
+github.com/dominodatalab/controller-util v0.0.0-20220506190502-be6562838a47 h1:BXO6xCqfLZng8Zt5YEht2iwHFR1OTzApRbMrOAXQk2U=
+github.com/dominodatalab/controller-util v0.0.0-20220506190502-be6562838a47/go.mod h1:Fp7RiFiZNfDJpijo2Nz4aQJ9483p+9OfwXzpNypllLA=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -493,8 +493,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/moby/buildkit v0.10.2 h1:jywa+mPPtsfCQqpIbt72RUKf49hTTCirTqIs4LG0n+8=
-github.com/moby/buildkit v0.10.2/go.mod h1:jxeOuly98l9gWHai0Ojrbnczrk/rf+o9/JqNhY+UCSo=
+github.com/moby/buildkit v0.10.3 h1:/dGykD8FW+H4p++q5+KqKEo6gAkYKyBQHdawdjVwVAU=
+github.com/moby/buildkit v0.10.3/go.mod h1:jxeOuly98l9gWHai0Ojrbnczrk/rf+o9/JqNhY+UCSo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.6.0 h1:gUDhXQx58YNrpHlK4nSL+7y2pxFZkUcXqzFDKWdC0Oo=

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -71,6 +71,10 @@ type ImageBuild struct {
 	Status ImageBuildStatus `json:"status,omitempty"`
 }
 
+func (in *ImageBuild) ObjectKey() client.ObjectKey {
+	return client.ObjectKey{Name: in.Name, Namespace: in.Namespace}
+}
+
 func (in *ImageBuild) GetConditions() *[]metav1.Condition {
 	return &in.Status.Conditions
 }

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -67,7 +67,7 @@ type ImageBuild struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec ImageBuildSpec `json:"spec,omitempty"`
-	// +kubebuilder:default={phase: "Created", transitions: {{previousPhase: "", phase: "Created", processed: false}}}
+	// +kubebuilder:default={phase: "Created", transitions: {{previousPhase: "", phase: "Created", processed: true}}}
 	Status ImageBuildStatus `json:"status,omitempty"`
 }
 

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -22,15 +22,14 @@ import (
 )
 
 type clientBuilder struct {
-	ctx              context.Context
 	addr             string
 	dockerAuthConfig string
 	log              logr.Logger
 	bkOpts           []bkclient.ClientOpt
 }
 
-func ClientBuilder(ctx context.Context, addr string) *clientBuilder {
-	return &clientBuilder{ctx: ctx, addr: addr, log: logr.Discard()}
+func ClientBuilder(addr string) *clientBuilder {
+	return &clientBuilder{addr: addr, log: logr.Discard()}
 }
 
 func (b *clientBuilder) WithDockerAuthConfig(configDir string) *clientBuilder {
@@ -54,15 +53,14 @@ func (b *clientBuilder) WithLogger(log logr.Logger) *clientBuilder {
 	return b
 }
 
-func (b *clientBuilder) Build() (*Client, error) {
-	bk, err := bkclient.New(b.ctx, b.addr, append(b.bkOpts, bkclient.WithFailFast())...)
+func (b *clientBuilder) Build(ctx context.Context) (*Client, error) {
+	bk, err := bkclient.New(ctx, b.addr, append(b.bkOpts, bkclient.WithFailFast())...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create buildkit client: %w", err)
 	}
 
 	return &Client{
 		bk:               bk,
-		ctx:              b.ctx,
 		log:              b.log,
 		dockerAuthConfig: b.dockerAuthConfig,
 	}, nil
@@ -79,18 +77,17 @@ type BuildOptions struct {
 }
 
 type Buildkit interface {
-	Build(opts BuildOptions) error
+	Build(ctx context.Context, opts BuildOptions) error
 	Cache(image string) error
 }
 
 type Client struct {
 	bk               *bkclient.Client
-	ctx              context.Context
 	log              logr.Logger
 	dockerAuthConfig string
 }
 
-func (c *Client) Build(opts BuildOptions) error {
+func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 	// setup build directory
 	buildDir, err := os.MkdirTemp("", "hephaestus-build-")
 	if err != nil {
@@ -111,7 +108,7 @@ func (c *Client) Build(opts BuildOptions) error {
 		contentsDir = opts.ContextDir
 	} else {
 		c.log.Info("Fetching remote context", "url", opts.Context)
-		extract, err := archive.FetchAndExtract(c.log, c.ctx, opts.Context, buildDir, 5*time.Minute)
+		extract, err := archive.FetchAndExtract(c.log, ctx, opts.Context, buildDir, 5*time.Minute)
 		if err != nil {
 			return fmt.Errorf("cannot fetch remote context: %w", err)
 		}
@@ -199,11 +196,11 @@ func (c *Client) Build(opts BuildOptions) error {
 	}
 
 	// build/push images
-	return c.runSolve(solveOpt)
+	return c.runSolve(ctx, solveOpt)
 }
 
 func (c *Client) Cache(image string) error {
-	return c.solveWith(func(buildDir string, solveOpt *bkclient.SolveOpt) error {
+	return c.solveWith(context.TODO(), func(buildDir string, solveOpt *bkclient.SolveOpt) error {
 		dockerfile := filepath.Join(buildDir, "Dockerfile")
 		contents := []byte(fmt.Sprintf("FROM %s\nRUN echo extract\n", image))
 		if err := os.WriteFile(dockerfile, contents, 0644); err != nil {
@@ -233,7 +230,7 @@ func (c *Client) Prune() error {
 	return nil
 }
 
-func (c *Client) solveWith(modify func(buildDir string, solveOpt *bkclient.SolveOpt) error) error {
+func (c *Client) solveWith(ctx context.Context, modify func(buildDir string, solveOpt *bkclient.SolveOpt) error) error {
 	buildDir, err := os.MkdirTemp("", "hephaestus-build-")
 	if err != nil {
 		return fmt.Errorf("failed to create build dir: %w", err)
@@ -256,13 +253,23 @@ func (c *Client) solveWith(modify func(buildDir string, solveOpt *bkclient.Solve
 		return err
 	}
 
-	return c.runSolve(solveOpt)
+	return c.runSolve(ctx, solveOpt)
 }
 
-func (c *Client) runSolve(so bkclient.SolveOpt) error {
+func (c *Client) runSolve(ctx context.Context, so bkclient.SolveOpt) error {
 	lw := &LogWriter{Logger: c.log}
 	ch := make(chan *bkclient.SolveStatus)
-	eg, ctx := errgroup.WithContext(c.ctx)
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		var c console.Console
+		if cn, err := console.ConsoleFromFile(os.Stderr); err != nil {
+			c = cn
+		}
+
+		_, err := progressui.DisplaySolveStatus(context.TODO(), "", c, lw, ch)
+		return err
+	})
 
 	eg.Go(func() error {
 		if _, err := c.bk.Solve(ctx, nil, so, ch); err != nil {
@@ -271,16 +278,6 @@ func (c *Client) runSolve(so bkclient.SolveOpt) error {
 
 		c.log.Info("Solve complete")
 		return nil
-	})
-
-	eg.Go(func() error {
-		var c console.Console
-		if cn, err := console.ConsoleFromFile(os.Stderr); err != nil {
-			c = cn
-		}
-
-		_, err := progressui.DisplaySolveStatus(ctx, "", c, lw, ch)
-		return err
 	})
 
 	if err := eg.Wait(); err != nil {

--- a/pkg/controller/imagebuild/component/deletebroadcaster.go
+++ b/pkg/controller/imagebuild/component/deletebroadcaster.go
@@ -37,10 +37,3 @@ func (c *DeleteBroadcastComponent) Reconcile(ctx *core.Context) (ctrl.Result, er
 
 	return ctrl.Result{}, nil
 }
-
-// ctx, cancel := context.WithCancel(coreCtx)
-// c.cancels.Store(obj.ObjectKey(), cancel)
-// defer func() {
-// 	cancel()
-// 	c.cancels.Delete(obj.ObjectKey())
-// }()

--- a/pkg/controller/imagebuild/component/deletebroadcaster.go
+++ b/pkg/controller/imagebuild/component/deletebroadcaster.go
@@ -1,0 +1,46 @@
+package component
+
+import (
+	"github.com/dominodatalab/controller-util/core"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
+)
+
+type DeleteBroadcastComponent struct {
+	delete chan<- client.ObjectKey
+}
+
+func DeleteBroadcaster(ch chan<- client.ObjectKey) *DeleteBroadcastComponent {
+	return &DeleteBroadcastComponent{
+		delete: ch,
+	}
+}
+
+func (c *DeleteBroadcastComponent) Reconcile(ctx *core.Context) (ctrl.Result, error) {
+	log := ctx.Log
+	obj := ctx.Object.(*hephv1.ImageBuild)
+	err := ctx.Client.Get(ctx, obj.ObjectKey(), &hephv1.ImageBuild{})
+
+	if err == nil {
+		return ctrl.Result{}, nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Broadcasting delete message")
+	c.delete <- obj.ObjectKey()
+
+	return ctrl.Result{}, nil
+}
+
+// ctx, cancel := context.WithCancel(coreCtx)
+// c.cancels.Store(obj.ObjectKey(), cancel)
+// defer func() {
+// 	cancel()
+// 	c.cancels.Delete(obj.ObjectKey())
+// }()

--- a/pkg/controller/imagebuild/imagebuild.go
+++ b/pkg/controller/imagebuild/imagebuild.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dominodatalab/controller-util/core"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
@@ -13,10 +14,12 @@ import (
 	"github.com/dominodatalab/hephaestus/pkg/controller/imagebuild/predicate"
 )
 
+var ch = make(chan client.ObjectKey)
+
 func Register(mgr ctrl.Manager, cfg config.Controller, pool workerpool.Pool) error {
 	return core.NewReconciler(mgr).
 		For(&hephv1.ImageBuild{}).
-		Component("build-dispatcher", component.BuildDispatcher(cfg.Buildkit, pool)).
+		Component("build-dispatcher", component.BuildDispatcher(cfg.Buildkit, pool, ch)).
 		WithControllerOptions(controller.Options{MaxConcurrentReconciles: cfg.ImageBuildMaxConcurrency}).
 		WithWebhooks().
 		Complete()
@@ -24,8 +27,17 @@ func Register(mgr ctrl.Manager, cfg config.Controller, pool workerpool.Pool) err
 
 func RegisterImageBuildStatus(mgr ctrl.Manager, cfg config.Controller) error {
 	return core.NewReconciler(mgr).
-		Named("imagebuildstatus").
 		For(&hephv1.ImageBuild{}, builder.WithPredicates(predicate.UnprocessedTransitionsPredicate{})).
+		Named("imagebuildstatus").
 		Component("status-messenger", component.StatusMessenger(cfg.Messaging)).
+		Complete()
+}
+
+func RegisterImageBuildDelete(mgr ctrl.Manager) error {
+	return core.NewReconciler(mgr).
+		For(&hephv1.ImageBuild{}, builder.WithPredicates(predicate.BlindDeletePredicate{})).
+		Named("imagebuilddelete").
+		Component("delete-broadcaster", component.DeleteBroadcaster(ch)).
+		ReconcileNotFound().
 		Complete()
 }

--- a/pkg/controller/imagebuild/predicate/predicate.go
+++ b/pkg/controller/imagebuild/predicate/predicate.go
@@ -8,6 +8,7 @@ import (
 )
 
 var _ predicate.Predicate = UnprocessedTransitionsPredicate{}
+var _ predicate.Predicate = BlindDeletePredicate{}
 
 // UnprocessedTransitionsPredicate implements an updated predicate function on ImageBuildTransition changes.
 //
@@ -30,3 +31,13 @@ func (p UnprocessedTransitionsPredicate) Update(e event.UpdateEvent) bool {
 func (p UnprocessedTransitionsPredicate) Create(event.CreateEvent) bool   { return false }
 func (p UnprocessedTransitionsPredicate) Delete(event.DeleteEvent) bool   { return false }
 func (p UnprocessedTransitionsPredicate) Generic(event.GenericEvent) bool { return false }
+
+// BlindDeletePredicate implements a deleted predicate function that always returns true.
+//
+// All other events are ignored.
+type BlindDeletePredicate struct{}
+
+func (p BlindDeletePredicate) Create(event.CreateEvent) bool   { return false }
+func (p BlindDeletePredicate) Delete(event.DeleteEvent) bool   { return true }
+func (p BlindDeletePredicate) Update(event.UpdateEvent) bool   { return false }
+func (p BlindDeletePredicate) Generic(event.GenericEvent) bool { return false }

--- a/pkg/controller/start.go
+++ b/pkg/controller/start.go
@@ -102,6 +102,11 @@ func Start(cfg config.Controller) error {
 		return err
 	}
 
+	log.Info("Registering ImageBuildDelete controller")
+	if err = imagebuild.RegisterImageBuildDelete(mgr); err != nil {
+		return err
+	}
+
 	log.Info("Registering ImageCache controller")
 	if err = imagecache.Register(mgr, cfg); err != nil {
 		return err


### PR DESCRIPTION
- separate context handling when build a new buildkit client and calling `Solve` on that client
- adds `DeleteBroadcaster` to watch for and emit messages when image build resources are deleted
- `BuildDispatcher` listens for and acts upon delete broadcasts to cancel buildkit `Solve` contexts.