### PR TITLE
Removes all traces of buildkit mTLS when disabled

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -1,6 +1,6 @@
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,BuildArgs
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,Images
-API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,ImportCacheFrom
+API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,ImportRemoteBuildCache
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,RegistryAuth
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildStatus,Conditions
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildStatus,Transitions
@@ -10,4 +10,4 @@ API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/ap
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageCacheStatus,CachedImages
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageCacheStatus,Conditions
 API rule violation: names_match,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,DisableCacheLayerExport
-API rule violation: names_match,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,ImportCacheFrom
+API rule violation: names_match,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,DisableLocalBuildCache

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1855,6 +1855,10 @@
           "description": "Context is a remote URL used to fetch the build context.",
           "type": "string"
         },
+        "disableBuildCache": {
+          "description": "DisableLocalBuildCache  will disable the use of the local cache when building the images.",
+          "type": "boolean"
+        },
         "disableCacheExport": {
           "description": "DisableCacheLayerExport will remove the \"inline\" cache metadata from the image configuration.",
           "type": "boolean"
@@ -1867,8 +1871,8 @@
             "default": ""
           }
         },
-        "importCache": {
-          "description": "ImportCacheFrom one or more canonical image references when building the images.",
+        "importRemoteBuildCache": {
+          "description": "ImportRemoteBuildCache from one or more canonical image references when building the images.",
           "type": "array",
           "items": {
             "type": "string",
@@ -1878,10 +1882,6 @@
         "logKey": {
           "description": "LogKey is used to uniquely annotate build logs for post-processing",
           "type": "string"
-        },
-        "noBuildCache": {
-          "description": "NoBuildCache will disable the use of the local cache when building the images.",
-          "type": "boolean"
         },
         "registryAuth": {
           "description": "RegistryAuth credentials used to pull/push images from/to private registries.",

--- a/deployments/helm/hephaestus/templates/certificates.yaml
+++ b/deployments/helm/hephaestus/templates/certificates.yaml
@@ -53,6 +53,7 @@ spec:
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.webhook.secret" . }}
 
+{{- if .Values.buildkit.mtls.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -86,3 +87,4 @@ spec:
     kind: Issuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.serverSecret" . }}
+{{- end }}

--- a/deployments/helm/hephaestus/templates/controller/deployment.yaml
+++ b/deployments/helm/hephaestus/templates/controller/deployment.yaml
@@ -67,12 +67,14 @@ spec:
               readOnly: true
               mountPath: /etc/hephaestus/config.yaml
               subPath: config.yaml
-            - name: mtls-vol
-              readOnly: true
-              mountPath: /etc/hephaestus/x509
             - name: webhook-vol
               readOnly: true
               mountPath: /tmp/k8s-webhook-server/serving-certs
+            {{- if .Values.buildkit.mtls.enabled }}
+            - name: mtls-vol
+              readOnly: true
+              mountPath: /etc/hephaestus/x509
+            {{- end }}
             {{- if .Values.logProcessor.enabled }}
             - name: log-vol
               mountPath: {{ include "hephaestus.logfileDir" . | quote }}
@@ -103,12 +105,14 @@ spec:
         - name: config-vol
           secret:
             secretName: {{ include "hephaestus.configSecretName" . }}
-        - name: mtls-vol
-          secret:
-            secretName: {{ include "hephaestus.buildkit.clientSecret" . }}
         - name: webhook-vol
           secret:
             secretName: {{ include "hephaestus.webhook.secret" . }}
+        {{- if .Values.buildkit.mtls.enabled }}
+        - name: mtls-vol
+          secret:
+            secretName: {{ include "hephaestus.buildkit.clientSecret" . }}
+        {{- end }}
         {{- if .Values.logProcessor.enabled }}
         - name: log-vol
           emptyDir: {}

--- a/deployments/helm/hephaestus/templates/controller/secret.yaml
+++ b/deployments/helm/hephaestus/templates/controller/secret.yaml
@@ -12,9 +12,12 @@ stringData:
       daemonPort: {{ .Values.buildkit.service.port }}
       serviceName: {{ include "hephaestus.buildkit.fullname" . }}
       statefulSetName: {{ include "hephaestus.buildkit.fullname" . }}
-      caCertPath: /etc/hephaestus/x509/ca.crt
-      certPath: /etc/hephaestus/x509/tls.crt
-      keyPath: /etc/hephaestus/x509/tls.key
+      {{- if .Values.buildkit.mtls.enabled }}
+      mtls:
+        caCertPath: /etc/hephaestus/x509/ca.crt
+        certPath: /etc/hephaestus/x509/tls.crt
+        keyPath: /etc/hephaestus/x509/tls.key
+      {{- end }}
       podLabels:
         {{- include "hephaestus.buildkit.labels.matchLabels" . | nindent 8 }}
       {{- with .Values.controller.poolSyncWaitTime }}

--- a/pkg/api/hephaestus/v1/zz_generated.openapi.go
+++ b/pkg/api/hephaestus/v1/zz_generated.openapi.go
@@ -243,9 +243,9 @@ func schema_pkg_api_hephaestus_v1_ImageBuildSpec(ref common.ReferenceCallback) c
 							Ref:         ref("github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1.ImageBuildAMQPOverrides"),
 						},
 					},
-					"importCache": {
+					"importRemoteBuildCache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ImportCacheFrom one or more canonical image references when building the images.",
+							Description: "ImportRemoteBuildCache from one or more canonical image references when building the images.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -258,9 +258,9 @@ func schema_pkg_api_hephaestus_v1_ImageBuildSpec(ref common.ReferenceCallback) c
 							},
 						},
 					},
-					"noBuildCache": {
+					"disableBuildCache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NoBuildCache will disable the use of the local cache when building the images.",
+							Description: "DisableLocalBuildCache  will disable the use of the local cache when building the images.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,12 @@ type Manager struct {
 	EnableLeaderElection bool     `json:"enableLeaderElection" yaml:"enableLeaderElection"`
 }
 
+type BuildkitMTLS struct {
+	CACertPath string `json:"caCertPath" yaml:"caCertPath"`
+	CertPath   string `json:"certPath" yaml:"certPath"`
+	KeyPath    string `json:"keyPath" yaml:"keyPath"`
+}
+
 type Buildkit struct {
 	Namespace       string            `json:"namespace" yaml:"namespace"`
 	PodLabels       map[string]string `json:"podLabels" yaml:"podLabels"`
@@ -83,12 +89,10 @@ type Buildkit struct {
 	ServiceName     string            `json:"serviceName" yaml:"serviceName"`
 	StatefulSetName string            `json:"statefulSetName" yaml:"statefulSetName"`
 
-	CACertPath string `json:"caCertPath" yaml:"caCertPath"`
-	CertPath   string `json:"certPath" yaml:"certPath"`
-	KeyPath    string `json:"keyPath" yaml:"keyPath"`
-
 	PoolSyncWaitTime *time.Duration `json:"poolSyncWaitTime" yaml:"poolSyncWaitTime"`
 	PoolMaxIdleTime  *time.Duration `json:"poolMaxIdleTime" yaml:"poolMaxIdleTime"`
+
+	MTLS *BuildkitMTLS `json:"mtls,omitempty" yaml:"mtls,omitempty"`
 }
 
 type Messaging struct {

--- a/scripts/sdk/generate.sh
+++ b/scripts/sdk/generate.sh
@@ -24,6 +24,7 @@ API_PACKAGE_PATH=pkg/api/hephaestus/v1
 OPENAPI_GEN_PATH=$PROJECT_NAME/$API_PACKAGE_PATH
 KUBERNETES_SWAGGER_FILE=/tmp/dist.swagger.json
 SWAGGER_FILE=api/openapi-spec/swagger.json
+REPORT_FILE=api/api-rules/violation_exceptions.list
 
 OPENAPI_GENERATOR_CLI_VERSION=v5.2.1
 
@@ -92,7 +93,7 @@ openapi-gen \
   --input-dirs $OPENAPI_GEN_PATH \
   --output-package $OPENAPI_GEN_PATH \
   --output-file-base zz_generated.openapi \
-  --report-filename $API_PACKAGE_PATH/zz_generated.violation_exceptions.list
+  --report-filename $REPORT_FILE
 
 generate_kubernetes_swagger
 


### PR DESCRIPTION
Inside the helm chart, when `buildkit.mtls.enabled=false`, buildkit does not use certs for mTLS. This change adds the same behavior to the controller and  does not render the buildkit certificates 