### PR TITLE
Enables multi-namespace helm chart deploy

### DIFF
--- a/deployments/helm/hephaestus/templates/_helpers.tpl
+++ b/deployments/helm/hephaestus/templates/_helpers.tpl
@@ -158,6 +158,13 @@ Return the buildkit fully-qualified app name.
 {{- end }}
 
 {{/*
+Return the namespace for buildkit-related resources.
+*/}}
+{{- define "hephaestus.buildkit.namespace" -}}
+{{- .Values.buildkit.namespace | default .Release.Namespace }}
+{{- end }}
+
+{{/*
 Return the buildkit standard labels.
 */}}
 {{- define "hephaestus.buildkit.labels.standard" -}}

--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
+  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 data:

--- a/deployments/helm/hephaestus/templates/buildkit/networkpolicy.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/networkpolicy.yaml
@@ -23,6 +23,6 @@ spec:
           {{- if ne (include "hephaestus.buildkit.namespace" .) .Release.Namespace }}
           namespaceSelector:
             matchLabels:
-              {{- toYaml (lookup "v1" "Namespace" "" .Release.Namespace).metadata.labels | nindent 14 }}
+              {{- .Values.buildkit.releaseNamespaceLabels | default (lookup "v1" "Namespace" "" .Release.Namespace).metadata.labels | toYaml | nindent 14 }}
           {{- end }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/networkpolicy.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
+  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 spec:
@@ -19,4 +20,9 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "hephaestus.controller.labels.matchLabels" . | nindent 14 }}
+          {{- if ne (include "hephaestus.buildkit.namespace" .) .Release.Namespace }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml (lookup "v1" "Namespace" "" .Release.Namespace).metadata.labels | nindent 14 }}
+          {{- end }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/podsecuritypolicy.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/podsecuritypolicy.yaml
@@ -74,5 +74,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "hephaestus.buildkit.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "hephaestus.buildkit.namespace" . }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/service.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
+  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 spec:

--- a/deployments/helm/hephaestus/templates/buildkit/serviceaccount.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "hephaestus.buildkit.serviceAccountName" . }}
+  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
   {{- with .Values.buildkit.serviceAccount.annotations }}

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
+  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 spec:

--- a/deployments/helm/hephaestus/templates/certificates.yaml
+++ b/deployments/helm/hephaestus/templates/certificates.yaml
@@ -1,5 +1,5 @@
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
   name: {{ include "hephaestus.certmanager.selfSignedIssuer" . }}
   labels:
@@ -12,6 +12,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "hephaestus.certmanager.selfSignedCA" . }}
+  namespace: {{ .Values.certManagerNamespace }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
@@ -23,12 +24,12 @@ spec:
     size: 256
   issuerRef:
     group: cert-manager.io
-    kind: Issuer
+    kind: ClusterIssuer
     name: {{ include "hephaestus.certmanager.selfSignedIssuer" . }}
 
 ---
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
   name: {{ include "hephaestus.certmanager.caIssuer" . }}
   labels:
@@ -49,7 +50,7 @@ spec:
     - {{ include "hephaestus.webhook.service" . }}.{{ .Release.Namespace }}.svc
     - {{ include "hephaestus.webhook.service" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
-    kind: Issuer
+    kind: ClusterIssuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.webhook.secret" . }}
 
@@ -66,7 +67,7 @@ spec:
   usages:
     - client auth
   issuerRef:
-    kind: Issuer
+    kind: ClusterIssuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.clientSecret" . }}
 
@@ -75,16 +76,17 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}-server
+  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   dnsNames:
     - "*.{{ include "hephaestus.buildkit.fullname" . }}"
-    - "*.{{ include "hephaestus.buildkit.fullname" . }}.{{ .Release.Namespace }}"
+    - "*.{{ include "hephaestus.buildkit.fullname" . }}.{{ include "hephaestus.buildkit.namespace" . }}"
   usages:
     - server auth
   issuerRef:
-    kind: Issuer
+    kind: ClusterIssuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.serverSecret" . }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/controller/secret.yaml
+++ b/deployments/helm/hephaestus/templates/controller/secret.yaml
@@ -8,7 +8,7 @@ type: Opaque
 stringData:
   config.yaml: |
     buildkit:
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "hephaestus.buildkit.namespace" . }}
       daemonPort: {{ .Values.buildkit.service.port }}
       serviceName: {{ include "hephaestus.buildkit.fullname" . }}
       statefulSetName: {{ include "hephaestus.buildkit.fullname" . }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -20,6 +20,10 @@ enableNetworkPolicies: true
 # This flag will have no effect in k8s >= 1.25.
 enablePodSecurityPolicies: false
 
+# Namespace where cert-manager is deployed. CA certificate secret needs to live in the cluster resource namespace.
+# https://cert-manager.io/docs/faq/cluster-resource/
+certManagerNamespace: cert-manager
+
 # Istio configuration
 istio:
   # Enable support for environments with Istio installed
@@ -201,6 +205,9 @@ buildkit:
   # Add a ConfigMap containing custom CAs if you need to push images to one or
   # more registries that use self-signed certificates
   customCABundle: ""
+
+  # Deploy buildkit workload into a namespace different from the release
+  namespace: ""
 
   # Buildkit image
   image:

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -206,8 +206,13 @@ buildkit:
   # more registries that use self-signed certificates
   customCABundle: ""
 
-  # Deploy buildkit workload into a namespace different from the release
+  # Deploy buildkit workload into a different namespace from the release
   namespace: ""
+
+  # The buildkit network policy will select against all the labels on the
+  # release namespace to allow ingress traffic from the controller by default.
+  # Use this field to limit the selector labels
+  releaseNamespaceLabels: {}
 
   # Buildkit image
   image:


### PR DESCRIPTION
Allows users to deploy controller and buildkit workloads into separate namespaces.