### PR TITLE
refactors controller command

### DIFF
--- a/pkg/cmd/controller/root.go
+++ b/pkg/cmd/controller/root.go
@@ -2,11 +2,8 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/dominodatalab/hephaestus/pkg/config"
 	"github.com/dominodatalab/hephaestus/pkg/controller"
@@ -22,36 +19,12 @@ func NewCommand() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "hephaestus.yaml", "configuration file")
 	cmd.AddCommand(
-		newInitCommand(),
 		newStartCommand(),
 		newCRDApplyCommand(),
 		newCRDDeleteCommand(),
 	)
 
 	return cmd
-}
-
-func newInitCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "init",
-		Short: "Generate config skeleton",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfg := config.GenerateDefaults()
-			fmt.Println(cfg)
-
-			bs, err := yaml.Marshal(cfg)
-			if err != nil {
-				return err
-			}
-
-			cfgFile, err := cmd.Flags().GetString("config")
-			if err != nil {
-				return err
-			}
-
-			return os.WriteFile(cfgFile, bs, 0644)
-		},
-	}
 }
 
 func newStartCommand() *cobra.Command {
@@ -66,6 +39,10 @@ func newStartCommand() *cobra.Command {
 
 			cfg, err := config.LoadFromFile(cfgFile)
 			if err != nil {
+				return err
+			}
+
+			if err = cfg.Validate(); err != nil {
 				return err
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,9 @@ type Controller struct {
 func (c Controller) Validate() error {
 	var errs []string
 
+	if c.ImageBuildMaxConcurrency < 1 {
+		errs = append(errs, "imageBuildMaxConcurrency must be greater than or equal to 1")
+	}
 	if c.Manager.HealthProbeAddr == "" {
 		errs = append(errs, "manager.healthProbeAddr cannot be blank")
 	}
@@ -113,38 +116,6 @@ type KafkaMessaging struct {
 	Servers   []string `json:"servers" yaml:"servers"`
 	Topic     string   `json:"topic" yaml:"topic"`
 	Partition string   `json:"partition" yaml:"partition"`
-}
-
-func GenerateDefaults() Controller {
-	return Controller{
-		Manager: Manager{
-			HealthProbeAddr:      ":8081",
-			MetricsAddr:          ":8080",
-			WebhookPort:          9443,
-			WatchNamespaces:      nil,
-			EnableLeaderElection: false,
-		},
-		Buildkit: Buildkit{
-			PodLabels: map[string]string{
-				"app": "buildkit",
-			},
-			ServiceName:     "buildkit",
-			StatefulSetName: "buildkit",
-			Namespace:       "default",
-			DaemonPort:      1234,
-		},
-		Logging: Logging{
-			StacktraceLevel: "warn",
-			Container: ContainerLogging{
-				Encoder:  "console",
-				LogLevel: "info",
-			},
-			Logfile: LogfileLogging{
-				LogLevel: "info",
-			},
-		},
-		ImageBuildMaxConcurrency: 5,
-	}
 }
 
 func LoadFromFile(filename string) (Controller, error) {


### PR DESCRIPTION
- adds config validation to start cmd
- validates ImageBuildMaxConcurrency value
- removes init command since (a) we don't use it and (b) this is not a
  really an application designed to run outside k8s nor be deployed
  without using the helm chart