### PR TITLE
buildkit: PVC labels are immutable, remove the chart version

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -133,7 +133,7 @@ spec:
     - metadata:
         name: cache
         labels:
-          {{- include "hephaestus.buildkit.labels.standard" . | nindent 10 }}
+          {{- include "hephaestus.buildkit.labels.matchLabels" . | nindent 10 }}
       spec:
         storageClassName: {{ .Values.buildkit.persistence.storageClass }}
         accessModes:


### PR DESCRIPTION
`labels.standard` include the chart version, which means every upgrade of hephaestus will fail because the PVC template label values are immutable.