### PR TITLE
Adds the ability to track "lease owner" in pod metadata

### DIFF
--- a/pkg/buildkit/worker/pool.go
+++ b/pkg/buildkit/worker/pool.go
@@ -43,6 +43,7 @@ var (
 
 const (
 	fieldManagerName     = "hephaestus-pod-lease-manager"
+	leasedAtAnnotation   = "hephaestus.dominodatalab.com/leased-at"
 	leasedByAnnotation   = "hephaestus.dominodatalab.com/leased-by"
 	managerIDAnnotation  = "hephaestus.dominodatalab.com/manager-identity"
 	expiryTimeAnnotation = "hephaestus.dominodatalab.com/expiry-time"
@@ -214,6 +215,7 @@ func (p *workerPool) leasePod(ctx context.Context, pod *corev1.Pod, owner string
 	}
 
 	pac.WithAnnotations(map[string]string{
+		leasedAtAnnotation:  time.Now().Format(time.RFC3339),
 		leasedByAnnotation:  owner,
 		managerIDAnnotation: p.uuid,
 	})
@@ -237,6 +239,7 @@ func (p *workerPool) releasePod(ctx context.Context, pod *corev1.Pod) error {
 	pac.WithAnnotations(map[string]string{
 		expiryTimeAnnotation: time.Now().Add(p.podMaxIdleTime).Format(time.RFC3339),
 	})
+	delete(pac.Annotations, leasedAtAnnotation)
 	delete(pac.Annotations, leasedByAnnotation)
 	delete(pac.Annotations, managerIDAnnotation)
 

--- a/pkg/buildkit/worker/pool.go
+++ b/pkg/buildkit/worker/pool.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Pool interface {
-	Get(ctx context.Context) (workerAddr string, err error)
+	Get(ctx context.Context, owner string) (workerAddr string, err error)
 	Release(ctx context.Context, workerAddr string) error
 	Close()
 }
@@ -43,7 +43,7 @@ var (
 
 const (
 	fieldManagerName     = "hephaestus-pod-lease-manager"
-	leasedAnnotation     = "hephaestus.dominodatalab.com/leased"
+	leasedByAnnotation   = "hephaestus.dominodatalab.com/leased-by"
 	managerIDAnnotation  = "hephaestus.dominodatalab.com/manager-identity"
 	expiryTimeAnnotation = "hephaestus.dominodatalab.com/expiry-time"
 )
@@ -129,7 +129,7 @@ func NewPool(ctx context.Context, clientset kubernetes.Interface, conf config.Bu
 			case <-wp.ctx.Done():
 				wp.log.Info("Shutting down worker pod monitor")
 				for wp.requests.Len() > 0 {
-					close(wp.requests.Dequeue())
+					close(wp.requests.Dequeue().result)
 				}
 
 				return
@@ -144,32 +144,26 @@ func NewPool(ctx context.Context, clientset kubernetes.Interface, conf config.Bu
 //
 // Adds "lease"/"manager-identity" metadata and removes "expiry-time".
 // The worker will remain leased until the caller provides the address to Release().
-func (p *workerPool) Get(ctx context.Context) (string, error) {
-	ch := make(chan PodRequestResult, 1)
+func (p *workerPool) Get(ctx context.Context, owner string) (string, error) {
+	request := &PodRequest{
+		owner:  owner,
+		result: make(chan PodRequestResult, 1),
+	}
 
-	p.requests.Enqueue(ch)
-	defer p.requests.Remove(ch)
+	p.requests.Enqueue(request)
+	defer p.requests.Remove(request)
 
 	p.triggerReconcile()
 
 	select {
-	case result := <-ch:
-		if result.err != nil {
-			return "", result.err
-		}
-
-		// when the channel is closed, we receive nil
-		if result.pod != nil {
-			addr, err := p.buildEndpointURL(ctx, result.pod.Name)
-			if err == nil {
-				return addr, nil
-			}
-			// when the url cannot be built, we release the pod
-			if rErr := p.releasePod(ctx, result.pod); rErr != nil {
-				p.log.Error(err, "Failed to release pod after URL build error")
+	case result, ok := <-request.result:
+		// check if channel is open before processing
+		if ok {
+			if result.err != nil {
+				return "", result.err
 			}
 
-			return "", err
+			return result.addr, nil
 		}
 	case <-ctx.Done():
 		// context has been cancelled
@@ -213,24 +207,24 @@ func (p *workerPool) Close() {
 }
 
 // applies lease metadata to given pod
-func (p *workerPool) leasePod(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, error) {
+func (p *workerPool) leasePod(ctx context.Context, pod *corev1.Pod, owner string) error {
 	pac, err := corev1ac.ExtractPod(pod, fieldManagerName)
 	if err != nil {
-		return nil, fmt.Errorf("cannot extract pod config: %w", err)
+		return fmt.Errorf("cannot extract pod config: %w", err)
 	}
 
 	pac.WithAnnotations(map[string]string{
-		leasedAnnotation:    "true",
+		leasedByAnnotation:  owner,
 		managerIDAnnotation: p.uuid,
 	})
 	delete(pac.Annotations, expiryTimeAnnotation)
 
 	p.log.Info("Applying pod metadata changes", "annotations", pac.Annotations)
-	if pod, err = p.podClient.Apply(ctx, pac, metav1.ApplyOptions{FieldManager: fieldManagerName}); err != nil {
-		return nil, fmt.Errorf("cannot update pod metadata: %w", err)
+	if _, err = p.podClient.Apply(ctx, pac, metav1.ApplyOptions{FieldManager: fieldManagerName}); err != nil {
+		return fmt.Errorf("cannot update pod metadata: %w", err)
 	}
 
-	return pod, nil
+	return nil
 }
 
 // removes lease metadata from given pod and adds expiry
@@ -243,7 +237,7 @@ func (p *workerPool) releasePod(ctx context.Context, pod *corev1.Pod) error {
 	pac.WithAnnotations(map[string]string{
 		expiryTimeAnnotation: time.Now().Add(p.podMaxIdleTime).Format(time.RFC3339),
 	})
-	delete(pac.Annotations, leasedAnnotation)
+	delete(pac.Annotations, leasedByAnnotation)
 	delete(pac.Annotations, managerIDAnnotation)
 
 	p.log.Info("Applying pod metadata changes", "annotations", pac.Annotations)
@@ -349,7 +343,7 @@ func (p *workerPool) updateWorkers(ctx context.Context) error {
 			log.Info("Eligible for termination, manager id mismatch", "expected", p.uuid, "actual", id)
 
 			removals = append(removals, pod.Name)
-		} else if _, hasLease := pod.Annotations[leasedAnnotation]; hasLease { // mark leased pods
+		} else if _, hasLease := pod.Annotations[leasedByAnnotation]; hasLease { // mark leased pods
 			log.Info("Ineligible for termination, pod is leased")
 
 			leased = append(leased, pod.Name)
@@ -357,21 +351,11 @@ func (p *workerPool) updateWorkers(ctx context.Context) error {
 			pending = append(pending, pod.Name)
 		} else if pod.Status.Phase == corev1.PodRunning { // dispatch builds/check expiry/check age on running pods
 			if req := p.requests.Dequeue(); req != nil {
-				log.Info("Found pending request, attempt to lease pod")
+				log.Info("Found pending pod request, processing")
 
-				var result PodRequestResult
-				if pod, err := p.leasePod(ctx, &pod); err != nil {
-					log.Error(err, "Failed to lease pod, requeueing request")
-					result = PodRequestResult{nil, err}
-				} else {
+				if p.processPodRequest(ctx, req, &pod) {
 					leased = append(leased, pod.Name)
-
-					log.Info("Pod leased, passing to request")
-					result = PodRequestResult{pod, nil}
 				}
-
-				req <- result
-
 				continue
 			}
 
@@ -439,6 +423,38 @@ func (p *workerPool) updateWorkers(ctx context.Context) error {
 		metav1.UpdateOptions{FieldManager: fieldManagerName},
 	)
 	return err
+}
+
+// attempts to lease a pod, build and endpoint url, and provide a request result
+func (p *workerPool) processPodRequest(ctx context.Context, req *PodRequest, pod *corev1.Pod) (success bool) {
+	log := p.log.WithValues("podName", pod.Name)
+
+	log.Info("Attempting to lease pod")
+	if err := p.leasePod(ctx, pod, req.owner); err != nil {
+		log.Error(err, "Failed to lease pod")
+
+		req.result <- PodRequestResult{err: err}
+		return
+	}
+
+	log.Info("Building endpoint URL")
+	addr, err := p.buildEndpointURL(ctx, pod.Name)
+
+	if err != nil {
+		log.Error(err, "Failed to build routable URL")
+
+		if rErr := p.releasePod(ctx, pod); rErr != nil {
+			log.Error(err, "Failed to release pod")
+		}
+
+		req.result <- PodRequestResult{err: err}
+		return
+	}
+
+	log.Info("Pod successfully leased, passing address to request owner")
+	req.result <- PodRequestResult{addr: addr}
+
+	return true
 }
 
 // trigger a pool reconciliation

--- a/pkg/buildkit/worker/requestqueue_test.go
+++ b/pkg/buildkit/worker/requestqueue_test.go
@@ -7,23 +7,23 @@ import (
 )
 
 func TestRequestQueue(t *testing.T) {
-	var ch1 chan PodRequestResult
-	var ch2 chan PodRequestResult
+	req1 := &PodRequest{}
+	req2 := &PodRequest{}
 
 	queue := NewRequestQueue()
 	assert.Equal(t, 0, queue.Len())
 	assert.Nil(t, queue.Dequeue())
-	assert.False(t, queue.Remove(ch1))
+	assert.False(t, queue.Remove(&PodRequest{}))
 
-	queue.Enqueue(ch1)
-	queue.Enqueue(ch2)
+	queue.Enqueue(req1)
+	queue.Enqueue(req2)
 	assert.Equal(t, 2, queue.Len())
-	assert.Equal(t, ch1, queue.Dequeue())
-	assert.Equal(t, ch2, queue.Dequeue())
+	assert.Equal(t, req1, queue.Dequeue())
+	assert.Equal(t, req2, queue.Dequeue())
 	assert.Equal(t, 0, queue.Len())
 
-	queue.Enqueue(ch1)
+	queue.Enqueue(req1)
 	assert.Equal(t, 1, queue.Len())
-	assert.True(t, queue.Remove(ch1))
+	assert.True(t, queue.Remove(req1))
 	assert.Equal(t, 0, queue.Len())
 }

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -90,7 +90,7 @@ func (c *BuildDispatcherComponent) Reconcile(ctx *core.Context) (ctrl.Result, er
 	allocStart := time.Now()
 
 	log.Info("Leasing buildkit worker")
-	addr, err := c.pool.Get(ctx)
+	addr, err := c.pool.Get(ctx, obj.ObjectKey().String())
 	if err != nil {
 		return ctrl.Result{}, c.phase.SetFailed(ctx, obj, fmt.Errorf("buildkit service lookup failed: %w", err))
 	}


### PR DESCRIPTION
- Adds `owner` param to `Pool.Get` interface
- Adds `PodRequest` type to carry owner and results channel
- Adds `leased-at` timestamp during lease action
- `PodRequestResult` now carries an address instead of a pod
- Stores owner name in pod's lease metadata
- Now leases/builds endpoint/releases in the event of a failures in sequence w/o channels