### PR TITLE
Logs solve error within Buildkit client

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -299,6 +299,7 @@ func (c *Client) runSolve(ctx context.Context, so bkclient.SolveOpt) error {
 	})
 
 	if err := eg.Wait(); err != nil {
+		c.log.Info(fmt.Sprintf("Build failed: %s", err.Error()))
 		return fmt.Errorf("buildkit solve issue: %w", err)
 	}
 


### PR DESCRIPTION
This log statement will have an associated `logKey` field and, hence, will be processed and shipped by vector. We're logging the stacktrace inside of the controller but I'm not sure there's a benefit to pushing it into the remote logs. Do you disagree @steved ?