### PR TITLE
Adds ListWorkers check when building buildkit client

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -73,7 +73,7 @@ func (b *clientBuilder) Build(ctx context.Context) (*Client, error) {
 	b.log.Info("Confirming buildkitd connectivity")
 	err = wait.ExponentialBackoffWithContext(ctx, clientCheckBackoff, func() (done bool, err error) {
 		if _, lastErr = bk.ListWorkers(ctx); lastErr != nil {
-			b.log.Info("Buildkitd is not ready")
+			b.log.V(1).Info("Buildkitd is not ready")
 			return false, nil
 		}
 
@@ -82,6 +82,7 @@ func (b *clientBuilder) Build(ctx context.Context) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to contact buildkitd after %d attempts: %w", clientCheckBackoff.Steps, lastErr)
 	}
+	b.log.Info("Buildkitd connectivity established")
 
 	return &Client{
 		bk:               bk,

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -23,10 +23,10 @@ import (
 	"github.com/dominodatalab/hephaestus/pkg/buildkit/archive"
 )
 
-var clientCheckBackoff = wait.Backoff{ // retries after 10ms 50ms 250ms 1250ms 6250ms
+var clientCheckBackoff = wait.Backoff{ // retries after 500ms 1s 2s 4s 8s with jitter
 	Steps:    5,
-	Duration: 10 * time.Millisecond,
-	Factor:   5.0,
+	Duration: 500 * time.Millisecond,
+	Factor:   2.0,
 	Jitter:   0.1,
 }
 


### PR DESCRIPTION
a new buildkit client does not verify its connection with a buildkitd
worker when first created so a garbage addr like "foo.bar:1234" will
not return an error. running a "list workers" operation like we do in
the statefulset readiness check for buildkit should solve this problem
and also guarantee that the TCP server has had time to set up its TLS
certificates.

retrying the operation with a backoff makes several attempts to
establish the connection before the client is returned to the caller