### PR TITLE
helm chart: fix image pull secrets rendering

### DIFF
--- a/deployments/helm/hephaestus/templates/_helpers.tpl
+++ b/deployments/helm/hephaestus/templates/_helpers.tpl
@@ -45,7 +45,7 @@ Return the controller service account name.
 Returns a unified list of image pull secrets.
 */}}
 {{- define "hephaestus.imagePullSecrets" -}}
-{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.controller.manager.image .Values.controller.vector.image .Values.buildkit.image) "global" .Values.global) }}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.controller.manager.image .Values.controller.vector.image .Values.buildkit.image) "context" $) }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The usage of `renderPullSecrets` is different than `pullSecrets`, but the usage here was for the latter not the former.

renderPullSecrets:
https://github.com/bitnami/charts/blob/dfffe74c212a28e27f537dbee54c3b5a81c7d572/bitnami/common/templates/_images.tpl#L51

pullSecrets:
https://github.com/bitnami/charts/blob/dfffe74c212a28e27f537dbee54c3b5a81c7d572/bitnami/common/templates/_images.tpl#L24

```
# before
$ helm template . --set "global.imagePullSecrets[0]=domino-quay-repos" | grep -A1 imagePullSecrets
[nil]
# after
$ helm template . --set "global.imagePullSecrets[0]=domino-quay-repos" | grep -A1 imagePullSecrets
      imagePullSecrets:
        - name: domino-quay-repos
--
      imagePullSecrets:
        - name: domino-quay-repos
--
      imagePullSecrets:
        - name: domino-quay-repos
--
      imagePullSecrets:
        - name: domino-quay-repos
```