### PR TITLE
support configuration of insecure registries

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -27,4 +27,15 @@ data:
         all = true
         keepBytes = {{ .gcKeepStorage | int64 }}
       {{- end }}
+
+    {{- range $domain, $opts := $.Values.registries }}
+    [registry."{{ $domain }}"]
+      {{- with $opts.http }}
+      http = {{ . }}
+      {{- end }}
+
+      {{- with $opts.insecure }}
+      insecure = {{ . }}
+      {{- end }}
+    {{- end }}
   {{- end }}

--- a/deployments/helm/hephaestus/templates/controller/secret.yaml
+++ b/deployments/helm/hephaestus/templates/controller/secret.yaml
@@ -41,6 +41,13 @@ stringData:
       secrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.registries }}
+      registries:
+        {{- range $domain, $opts := . }}
+        {{ $domain }}:
+          {{- toYaml $opts | nindent 10 }}
+        {{- end }}
+      {{- end }}
     {{- with .Values.controller.manager }}
     imageBuildMaxConcurrency: {{ .imageBuildMaxConcurrency }}
     manager:

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -43,6 +43,13 @@ newRelic:
   # Tag metadata added to metrics
   labels: {}
 
+# Configuration for buildkit and controller that adds the ability to pull/push images
+# from/to insecure (self-signed TLS) and http registries.
+registries: {}
+  # myserver:
+  #   insecure: true
+  #   http: true
+
 # Controller configuration
 controller:
   # Number of instances to run. Leader election will be enabled whenever this

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,11 +93,18 @@ type Buildkit struct {
 
 	Secrets map[string]string `json:"secrets" yaml:"secrets,omitempty"`
 
+	Registries map[string]RegistryConfig `json:"registries,omitempty" yaml:"registries,omitempty"`
+
 	PoolSyncWaitTime *time.Duration `json:"poolSyncWaitTime" yaml:"poolSyncWaitTime"`
 	PoolMaxIdleTime  *time.Duration `json:"poolMaxIdleTime" yaml:"poolMaxIdleTime"`
 	PoolWatchTimeout *int64         `json:"poolWatchTimeout" yaml:"poolWatchTimeout"`
 
 	MTLS *BuildkitMTLS `json:"mtls,omitempty" yaml:"mtls,omitempty"`
+}
+
+type RegistryConfig struct {
+	Insecure bool `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	HTTP     bool `json:"http,omitempty" yaml:"http,omitempty"`
 }
 
 type BuildkitMTLS struct {

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -122,7 +122,7 @@ func Persist(ctx context.Context, cfg *rest.Config, credentials []hephv1.Registr
 	return dir, err
 }
 
-func Verify(ctx context.Context, configDir string) error {
+func Verify(ctx context.Context, configDir string, insecureRegistries []string) error {
 	filename := filepath.Join(configDir, "config.json")
 	data, err := os.ReadFile(filename)
 	if err != nil {
@@ -134,7 +134,7 @@ func Verify(ctx context.Context, configDir string) error {
 		return err
 	}
 
-	svc, err := registry.NewService(registry.ServiceOptions{})
+	svc, err := registry.NewService(registry.ServiceOptions{InsecureRegistries: insecureRegistries})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In Forge, we allowed setting of insecure registries [on the objects themselves](https://github.com/dominodatalab/hephaestus/blob/747da51794616fe700c302e7c21c18a842e8159e/pkg/api/forge/v1alpha1/containerimagebuild_types.go#L64), which did not make it to Hephaestus.

Unfortunately, the only way to configure HTTP-only or insecure HTTPS registry hosts is [through the buildkitd.toml](https://github.com/moby/buildkit/issues/2044#issuecomment-811489932) config. This makes it impossible to set them per-image build and requires deploy-time configuration.

To support credential validation against HTTP-only or insecure registries, the info needs to be passed to the controller as well.