### PR TITLE
adds psp for hephaestus manager

### DIFF
--- a/deployments/helm/hephaestus/templates/_helpers.tpl
+++ b/deployments/helm/hephaestus/templates/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Return the controller manager name.
+*/}}
+{{- define "hephaestus.manager.name" -}}
+{{ include "common.names.fullname" . }}-manager
+{{- end }}
+
+{{/*
 Return the controller manager image name.
 */}}
 {{- define "hephaestus.manager.image" -}}

--- a/deployments/helm/hephaestus/templates/controller/clusterrole.yaml
+++ b/deployments/helm/hephaestus/templates/controller/clusterrole.yaml
@@ -98,11 +98,13 @@ rules:
     verbs:
       - list
       - watch
-  {{- if or (include "hephaestus.pspRequired" .) (include "hephaestus.istioWithoutCNI" .) }}
+  {{- if include "hephaestus.pspRequired" . }}
   - apiGroups:
       - policy
     resources:
       - podsecuritypolicies
+    resourceNames:
+      - {{ include "hephaestus.manager.name" . }}
     verbs:
       - use
   {{- end }}

--- a/deployments/helm/hephaestus/templates/controller/deployment.yaml
+++ b/deployments/helm/hephaestus/templates/controller/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "common.names.fullname" . }}-manager
+  name: {{ include "hephaestus.manager.name" . }}
   labels:
     {{- include "hephaestus.controller.labels.standard" . | nindent 4 }}
 spec:

--- a/deployments/helm/hephaestus/templates/controller/podsecuritypolicy.yaml
+++ b/deployments/helm/hephaestus/templates/controller/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if include "hephaestus.pspRequired" . }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "hephaestus.manager.name" . }}
+  labels:
+    {{- include "hephaestus.controller.labels.standard" . | nindent 4 }}
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  {{- if include "hephaestus.istioWithoutCNI" . }}
+  allowedCapabilities:
+    - NET_ADMIN
+    - NET_RAW
+  {{- else }}
+  requiredDropCapabilities:
+    - ALL
+  {{- end }}
+  runAsUser:
+    rule: {{ if include "hephaestus.istioWithoutCNI" . }}RunAsAny{{ else }}MustRunAsNonRoot{{ end }}
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - configMap
+    - emptyDir
+    - projected
+    - secret
+    - downwardAPI
+    - persistentVolumeClaim
+{{- end }}


### PR DESCRIPTION
we were adding a "use" stanza to the clusterrole without indicating a
specific psp (i.e. blind usage). this adds a dedicated psp for the
manager pods rather than remove the stanza and assume there is some
default psp that grants us all the rights we need