### PR TITLE
Add cloud-base registry configuration values to Helm chart

### DIFF
--- a/deployments/helm/hephaestus/templates/controller/deployment.yaml
+++ b/deployments/helm/hephaestus/templates/controller/deployment.yaml
@@ -42,9 +42,23 @@ spec:
           args:
             - start
             - --config=/etc/hephaestus/config.yaml
-          {{- with .Values.controller.manager.extraEnvVars }}
+          {{- with .Values.controller.manager }}
+          {{- if or .extraEnvVars .cloudRegistryAuth.azure.enabled }}
           env:
+            {{- with .extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+            {{- end }}
+            {{- if .cloudRegistryAuth.azure.enabled }}
+            - name: AZURE_TENANT_ID
+              value: {{ required "Azure tenantID is required when enabled!" .cloudRegistryAuth.azure.tenantID | quote }}
+            - name: AZURE_CLIENT_ID
+              value: {{ required "Azure clientID is required when enabled!" .cloudRegistryAuth.azure.clientID | quote }}
+            {{- with .cloudRegistryAuth.azure.clientSecret }}
+            - name: AZURE_CLIENT_SECRET
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
           {{- end }}
           ports:
             {{- with .Values.controller.manager }}

--- a/deployments/helm/hephaestus/templates/controller/serviceaccount.yaml
+++ b/deployments/helm/hephaestus/templates/controller/serviceaccount.yaml
@@ -5,8 +5,15 @@ metadata:
   name: {{ include "hephaestus.serviceAccountName" . }}
   labels:
     {{- include "hephaestus.controller.labels.standard" . | nindent 4 }}
-  {{- with .Values.controller.serviceAccount.annotations }}
+  {{- with .Values.controller }}
+  {{- if or .manager.cloudRegistryAuth.gcp.serviceAccount .serviceAccount.annotations }}
   annotations:
+    {{- with .manager.cloudRegistryAuth.gcp.serviceAccount }}
+    "iam.gke.io/gcp-service-account": {{ . | quote }}
+    {{- end }}
+    {{- with .serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/controller/serviceaccount.yaml
+++ b/deployments/helm/hephaestus/templates/controller/serviceaccount.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     {{- include "hephaestus.controller.labels.standard" . | nindent 4 }}
   {{- with .Values.controller }}
-  {{- if or .manager.cloudRegistryAuth.gcp.serviceAccount .serviceAccount.annotations }}
+  {{- if or .serviceAccount.annotations .manager.cloudRegistryAuth.gcp.enabled }}
   annotations:
-    {{- with .manager.cloudRegistryAuth.gcp.serviceAccount }}
-    "iam.gke.io/gcp-service-account": {{ . | quote }}
-    {{- end }}
     {{- with .serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .manager.cloudRegistryAuth.gcp.enabled }}
+    "iam.gke.io/gcp-service-account": {{ required "GCP ServiceAccount is required when enabled!" .manager.cloudRegistryAuth.gcp.serviceAccount | quote }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -152,11 +152,13 @@ controller:
     cloudRegistryAuth:
       # Azure credentials required to access ACR
       azure:
+        enabled: false
         tenantID: ""
         clientID: ""
         clientSecret: ""
       # GCP credentials required to access GCR
       gcp:
+        enabled: false
         serviceAccount: ""
 
     # Build status messaging configuration

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -148,6 +148,17 @@ controller:
     # Secrets (name: path) to expose into builds that request it
     secrets: {}
 
+    # Cloud-based registry credentials configuration
+    cloudRegistryAuth:
+      # Azure credentials required to access ACR
+      azure:
+        tenantID: ""
+        clientID: ""
+        clientSecret: ""
+      # GCP credentials required to access GCR
+      gcp:
+        serviceAccount: ""
+
     # Build status messaging configuration
     messaging:
       # Enable message publisher


### PR DESCRIPTION
Creates configurations for both GCP and Azure in order to access GCR and ACR, respectively. ECR has not been added because we rely on the underlying IAM Role -> Instance Profile to provide credentials. Obviously, we can change and/or extend this as-needed in the future.