### PR TITLE
Removes server name checking from secret-based registry auth

### DIFF
--- a/pkg/api/hephaestus/v1/types.go
+++ b/pkg/api/hephaestus/v1/types.go
@@ -37,6 +37,11 @@ type SecretCredentials struct {
 }
 
 type RegistryCredentials struct {
+	// NOTE: this field was previously used to assert the presence of an auth entry inside of secret credentials. if the
+	//  the Server was missing, then an error was raised. this design is limiting because it requires users to create
+	//  several `registryAuth` items with the same secret if they want to verify the presence. in a future api version,
+	//  we may remove the Server field from this type and replace it with one or more fields that service the needs all
+	//  credential types.
 	Server string `json:"server,omitempty"`
 
 	CloudProvided *bool                 `json:"cloudProvided,omitempty"`

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -26,32 +26,16 @@ import (
 
 var CloudAuthRegistry = &cloudauth.Registry{}
 
+var clientsetFunc = func(config *rest.Config) (kubernetes.Interface, error) {
+	return kubernetes.NewForConfig(config)
+}
+
 // AuthConfigs is a map of registry urls to authentication credentials.
 type AuthConfigs map[string]types.AuthConfig
 
 // DockerConfigJSON models the structure of .dockerconfigjson data.
 type DockerConfigJSON struct {
 	Auths AuthConfigs `json:"auths"`
-}
-
-func Extract(host string, data []byte) (string, string, error) {
-	var conf DockerConfigJSON
-	if err := json.Unmarshal(data, &conf); err != nil {
-		//nolint:nilerr // TODO: should we return an error here?
-		return "", "", nil
-	}
-
-	ac, ok := conf.Auths[host]
-	if !ok {
-		var servers []string
-		for url := range conf.Auths {
-			servers = append(servers, url)
-		}
-
-		return "", "", fmt.Errorf("registry %q is not in server list %v", host, servers)
-	}
-
-	return ac.Username, ac.Password, nil
 }
 
 func Persist(ctx context.Context, cfg *rest.Config, credentials []hephv1.RegistryCredentials) (string, error) {
@@ -65,13 +49,8 @@ func Persist(ctx context.Context, cfg *rest.Config, credentials []hephv1.Registr
 		var ac types.AuthConfig
 
 		switch {
-		case cred.BasicAuth != nil:
-			ac = types.AuthConfig{
-				Username: cred.BasicAuth.Username,
-				Password: cred.BasicAuth.Password,
-			}
 		case cred.Secret != nil:
-			clientset, err := kubernetes.NewForConfig(cfg)
+			clientset, err := clientsetFunc(cfg)
 			if err != nil {
 				return "", err
 			}
@@ -86,14 +65,20 @@ func Persist(ctx context.Context, cfg *rest.Config, credentials []hephv1.Registr
 				return "", fmt.Errorf("invalid secret")
 			}
 
-			username, password, err := Extract(cred.Server, secret.Data[corev1.DockerConfigJsonKey])
-			if err != nil {
+			var conf DockerConfigJSON
+			if err := json.Unmarshal(secret.Data[corev1.DockerConfigJsonKey], &conf); err != nil {
 				return "", err
 			}
 
+			for server, config := range conf.Auths {
+				auths[server] = config
+			}
+
+			continue
+		case cred.BasicAuth != nil:
 			ac = types.AuthConfig{
-				Username: username,
-				Password: password,
+				Username: cred.BasicAuth.Username,
+				Password: cred.BasicAuth.Password,
 			}
 		case pointer.BoolDeref(cred.CloudProvided, false):
 			pac, err := CloudAuthRegistry.RetrieveAuthorization(ctx, cred.Server)

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -1,0 +1,71 @@
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
+)
+
+func TestPersist(t *testing.T) {
+	t.Run("all_secret_auths", func(t *testing.T) {
+		config := DockerConfigJSON{
+			Auths: AuthConfigs{
+				"registry1.com": types.AuthConfig{
+					Username: "happy",
+					Password: "gilmore",
+				},
+				"registry2.com": types.AuthConfig{
+					Username: "billy",
+					Password: "madison",
+				},
+			},
+		}
+		expected, err := json.Marshal(config)
+		require.NoError(t, err)
+
+		clientsetFunc = func(*rest.Config) (kubernetes.Interface, error) {
+			return fake.NewSimpleClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-creds",
+					Namespace: "test-ns",
+				},
+				Data:       map[string][]byte{corev1.DockerConfigJsonKey: expected},
+				StringData: nil,
+				Type:       corev1.SecretTypeDockerConfigJson,
+			}), nil
+		}
+
+		credentials := []hephv1.RegistryCredentials{
+			{
+				Secret: &hephv1.SecretCredentials{
+					Name:      "test-creds",
+					Namespace: "test-ns",
+				},
+			},
+		}
+
+		configPath, err := Persist(context.Background(), nil, credentials)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.RemoveAll(configPath)
+		})
+
+		actual, err := os.ReadFile(filepath.Join(configPath, "config.json"))
+		require.NoError(t, err)
+
+		assert.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
If a user wants to authenticate with 2 or more registries contained within a single k8s secret, then they are required to create an `ImageBuild` with the following auth section:

```yaml
registryAuths:
- server: "server1"
  secret:
    name: many-registry-auths
    namespace: ns
- server: "server2"
  secret:
    name: many-registry-auths
    namespace: ns
```

and this can become somewhat cumbersome as that list grows. Furthermore, the `server` field for secrets is meant to server as a verification mechanism (i.e. an error will be raised if it's missing from the underlying secret data). I think we can add the verification to another field, or implement a different way that removes the labor involved here. For now, I'm disabling it and promoting all auths contained within the secret over to buildkit.

/cc @ddl-kevin 