### PR TITLE
only change buildkit fsGroup during mismatch or initial pod startup

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -32,8 +32,9 @@ spec:
     spec:
       {{- include "hephaestus.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "hephaestus.buildkit.fullname" . }}
-      {{- if .Values.buildkit.rootless }}
       securityContext:
+        fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.buildkit.rootless }}
         fsGroup: 1000
       {{- end }}
       containers:


### PR DESCRIPTION
When `fsGroup` runs on an already-existing volume when buildkit is scaled back up it can materially change the GID of unpacked snapshots from container images that can cause future build failures.