### PR TITLE
Makes ACR cloudauth messages more informative

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,3 +75,7 @@ issues:
       text: "waitForIstioSidecar"
       linters:
         - contextcheck
+    - path: pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+      text: "NewFromConfig"
+      linters:
+        - contextcheck

--- a/pkg/controller/start.go
+++ b/pkg/controller/start.go
@@ -69,7 +69,7 @@ func Start(cfg config.Controller) error {
 	}
 
 	log.Info("Registering cloud auth providers")
-	if err = credentials.LoadCloudProviders(log); err != nil {
+	if err = credentials.LoadCloudProviders(ctx, log); err != nil {
 		return err
 	}
 

--- a/pkg/controller/support/credentials/cloudauth/acr/acr_integration_test.go
+++ b/pkg/controller/support/credentials/cloudauth/acr/acr_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/dominodatalab/hephaestus/pkg/controller/support/credentials/cloudauth"
 )
 
-func TestRegister(t *testing.T) {
+func TestRegisterIntegration(t *testing.T) {
 	if os.Getenv(auth.ClientSecret) == "" {
 		t.Skip("Skipping, azure not setup")
 	}
@@ -30,7 +30,7 @@ func TestRegister(t *testing.T) {
 	}
 }
 
-func TestRegisterNoSecret(t *testing.T) {
+func TestRegisterNoSecretIntegration(t *testing.T) {
 	secret := os.Getenv(auth.ClientSecret)
 	os.Unsetenv(auth.ClientSecret)
 	t.Cleanup(func() {
@@ -46,7 +46,7 @@ func TestRegisterNoSecret(t *testing.T) {
 	}
 }
 
-func TestAuthenticate(t *testing.T) {
+func TestAuthenticateIntegration(t *testing.T) {
 	if os.Getenv(auth.ClientSecret) == "" {
 		t.Skip("Skipping, azure not setup")
 	}

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -32,8 +32,8 @@ var (
 	)
 )
 
-func Register(logger logr.Logger, registry *cloudauth.Registry) error {
-	config, err := config.LoadDefaultConfig(context.Background(), config.WithEC2IMDSRegion())
+func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Registry) error {
+	config, err := config.LoadDefaultConfig(ctx, config.WithEC2IMDSRegion())
 	if err != nil {
 		logger.Info("ECR not registered", "error", err)
 		return nil

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -45,8 +45,8 @@ type gcrProvider struct {
 	tokenSource oauth2.TokenSource
 }
 
-func Register(logger logr.Logger, registry *cloudauth2.Registry) error {
-	provider, err := newProvider(context.Background(), logger)
+func Register(ctx context.Context, logger logr.Logger, registry *cloudauth2.Registry) error {
+	provider, err := newProvider(ctx, logger)
 	if err != nil {
 		logger.Info("GCR not registered", "error", err)
 		if strings.Contains(err.Error(), "could not find default credentials") {
@@ -66,7 +66,7 @@ func newProvider(ctx context.Context, logger logr.Logger) (*gcrProvider, error) 
 		return nil, err
 	}
 
-	return &gcrProvider{logger: logger.WithName("gcrProvider"), tokenSource: creds.TokenSource}, nil
+	return &gcrProvider{logger: logger.WithName("gcr-auth-provider"), tokenSource: creds.TokenSource}, nil
 }
 
 func (g *gcrProvider) authenticate(ctx context.Context, server string) (*types.AuthConfig, error) {

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -83,7 +83,7 @@ func Persist(ctx context.Context, cfg *rest.Config, credentials []hephv1.Registr
 		case pointer.BoolDeref(cred.CloudProvided, false):
 			pac, err := CloudAuthRegistry.RetrieveAuthorization(ctx, cred.Server)
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("cloud registry authorization failed: %w", err)
 			}
 
 			ac = *pac
@@ -142,14 +142,14 @@ func Verify(ctx context.Context, configDir string, insecureRegistries []string) 
 }
 
 // LoadCloudProviders adds all cloud authentication providers to the CloudAuthRegistry.
-func LoadCloudProviders(log logr.Logger) error {
-	if err := acr.Register(log, CloudAuthRegistry); err != nil {
+func LoadCloudProviders(ctx context.Context, log logr.Logger) error {
+	if err := acr.Register(ctx, log, CloudAuthRegistry); err != nil {
 		return fmt.Errorf("ACR registration failed: %w", err)
 	}
-	if err := ecr.Register(log, CloudAuthRegistry); err != nil {
+	if err := ecr.Register(ctx, log, CloudAuthRegistry); err != nil {
 		return fmt.Errorf("ECR registration failed: %w", err)
 	}
-	if err := gcr.Register(log, CloudAuthRegistry); err != nil {
+	if err := gcr.Register(ctx, log, CloudAuthRegistry); err != nil {
 		return fmt.Errorf("GCR registration failed: %w", err)
 	}
 


### PR DESCRIPTION
- passes ctx when registering providers
- checks for the presence of envvars to decide if ACR should be enabled; errors out if credentials are incomplete or incorrect