### PR TITLE
Moves from discoveryv1beta1 to discoveryv1 API for EndpointSlices

### DIFF
--- a/pkg/buildkit/worker/pool_test.go
+++ b/pkg/buildkit/worker/pool_test.go
@@ -12,7 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,7 +46,7 @@ var (
 			Namespace: namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: pointer.Int32Ptr(0),
+			Replicas: pointer.Int32(0),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: testLabels,
 			},
@@ -89,14 +89,14 @@ var (
 		},
 	}
 
-	validEndpointSlice = &discoveryv1beta1.EndpointSlice{
+	validEndpointSlice = &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "buildkit-bgk87",
 			Namespace: namespace,
 		},
-		Endpoints: []discoveryv1beta1.Endpoint{
+		Endpoints: []discoveryv1.Endpoint{
 			{
-				Conditions: discoveryv1beta1.EndpointConditions{
+				Conditions: discoveryv1.EndpointConditions{
 					Ready:   pointer.Bool(true),
 					Serving: pointer.Bool(true),
 				},
@@ -107,7 +107,7 @@ var (
 				},
 			},
 		},
-		Ports: []discoveryv1beta1.EndpointPort{
+		Ports: []discoveryv1.EndpointPort{
 			{
 				Name: pointer.String("daemon"),
 				Port: pointer.Int32(1234),

--- a/scripts/development/01-setup-minikube.sh
+++ b/scripts/development/01-setup-minikube.sh
@@ -7,8 +7,8 @@
 
 set -e
 
+# TODO: we should be able to select and test against different versions of k8s
 minikube start \
-  --kubernetes-version=v1.19.16 \
   --extra-config=apiserver.service-node-port-range=1-65535 \
   --cpus=4 \
   --memory=16g \


### PR DESCRIPTION
The former has been removed in k8s 1.25 since we no longer need to support k8s < 1.21. _Mo' versions, mo' problems._