### PR TITLE
Buildkit worker pool uses podMaxIdleTime for pending pods

### DIFF
--- a/pkg/buildkit/worker/pool.go
+++ b/pkg/buildkit/worker/pool.go
@@ -395,8 +395,8 @@ func (p *AutoscalingPool) updateWorkers(ctx context.Context) error {
 		} else if pod.Status.Phase == corev1.PodPending { // mark pending pods
 			pending = append(pending, pod.Name)
 
-			if time.Since(pod.CreationTimestamp.Time) < p.podMaxIdleTime {
-				log.Info("Pending pod is not old enough for terminate")
+			if elapsed := time.Since(pod.CreationTimestamp.Time); elapsed < p.podMaxIdleTime {
+				log.Info("Pending pod is not old enough for termination", "gracePeriod", p.podMaxIdleTime-elapsed)
 				pendingGracePeriodOffset++
 			}
 		} else if p.isOperationalPod(ctx, pod.Name) { // dispatch builds/check expiry/check age on operation pods

--- a/pkg/buildkit/worker/pool_test.go
+++ b/pkg/buildkit/worker/pool_test.go
@@ -156,8 +156,9 @@ func assertLeasedPod(t *testing.T, action k8stesting.Action, ret *corev1.Pod) {
 }
 
 // NOTE: this set of assertions is fine, but it's not great. we need a better way of asserting the patching.
-//  ideally, we would make assertions against the API object after the event but client-go doesn't support SSA right
-//  now, which means we have to override the "patch" action with a reactor.
+//	ideally, we would make assertions against the API object after the event but client-go doesn't support SSA right
+//	now, which means we have to override the "patch" action with a reactor.
+
 func assertUnleasedPod(t *testing.T, action k8stesting.Action) {
 	t.Helper()
 
@@ -969,6 +970,26 @@ func TestPoolPodReconciliation(t *testing.T) {
 			},
 			requests: 1,
 			expected: 1,
+		},
+		{
+			name: "combination_embedded_new_pending",
+			objects: func() []runtime.Object {
+				p0 := validPod.DeepCopy()
+				p0.Name = "buildkit-0"
+				p0.CreationTimestamp = metav1.Time{Time: time.Now()}
+
+				p1 := validPod.DeepCopy()
+				p1.Name = "buildkit-1"
+				p1.Status.Phase = corev1.PodPending
+				p1.CreationTimestamp = metav1.Time{Time: time.Now().Add(-5 * time.Minute)}
+
+				p2 := validPod.DeepCopy()
+				p2.Name = "buildkit-2"
+				p2.CreationTimestamp = metav1.Time{Time: time.Now()}
+
+				return []runtime.Object{p0, p1, p2}
+			},
+			expected: 3,
 		},
 	}
 

--- a/pkg/buildkit/worker/pool_test.go
+++ b/pkg/buildkit/worker/pool_test.go
@@ -155,10 +155,9 @@ func assertLeasedPod(t *testing.T, action k8stesting.Action, ret *corev1.Pod) {
 	ret.Annotations = pod.Annotations
 }
 
-// NOTE: this set of assertions is fine, but it's not great. we need a better way of asserting the patching. ideally, we
-//
-//	would make assertions against the API object after the event but client-go doesn't support SSA right now, which
-//	means we have to override the "patch" action with a reactor.
+// NOTE: this set of assertions is fine, but it's not great. we need a better way of asserting the patching.
+//  ideally, we would make assertions against the API object after the event but client-go doesn't support SSA right
+//  now, which means we have to override the "patch" action with a reactor.
 func assertUnleasedPod(t *testing.T, action k8stesting.Action) {
 	t.Helper()
 
@@ -737,10 +736,22 @@ func TestPoolPodReconciliation(t *testing.T) {
 			expected: 0,
 		},
 		{
-			name: "pending",
+			name: "pending_new",
 			objects: func() []runtime.Object {
 				p := validPod.DeepCopy()
 				p.Status.Phase = corev1.PodPending
+				p.CreationTimestamp = metav1.NewTime(time.Now())
+
+				return []runtime.Object{p}
+			},
+			expected: 1,
+		},
+		{
+			name: "pending_old",
+			objects: func() []runtime.Object {
+				p := validPod.DeepCopy()
+				p.Status.Phase = corev1.PodPending
+				p.CreationTimestamp = metav1.NewTime(time.Now().Add(-15 * time.Minute))
 
 				return []runtime.Object{p}
 			},


### PR DESCRIPTION
so that pending pods are afforded the same grace period as running pods before termination