### PR TITLE
Do not auto-delete CRDs on helm uninstall

### DIFF
--- a/deployments/helm/hephaestus/templates/crd-hooks.yaml
+++ b/deployments/helm/hephaestus/templates/crd-hooks.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.installCRDs }}
 {{- $serviceAccountName := printf "%s-hook" (include "hephaestus.serviceAccountName" .) -}}
 {{- $hookName := printf "%s:hook" (include "hephaestus.rbac.managerName" .) -}}
+
+{{- if or .Values.installCRDs .Values.uninstallCRDs }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -61,7 +62,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ $serviceAccountName }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 
+{{- if .Values.installCRDs }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -117,7 +120,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}
 
+{{- if .Values.uninstallCRDs }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -9,9 +9,12 @@ nameOverride: ""
 # Replace the generated name (release+chart name)
 fullnameOverride: ""
 
-# If true, CRD resources will be installed/uninstalled as part of the Helm chart release.
-# Uninstalling CRD resources will DELETE all related custom resources.
+# If true, CRD resources will be installed as part of the Helm chart release.
 installCRDs: true
+
+# If true, CRD resources will be uninstalled as part of the Helm chart release uninstallation.
+# Uninstalling CRD resources will DELETE all related custom resources.
+uninstallCRDs: false
 
 # Restrict network access to controller and buildkit pods
 enableNetworkPolicies: true


### PR DESCRIPTION
adds `.Values.uninstallCRDs` to helm chart

by default, this chart will no longer uninstall the CRDs when the helm chart release is deleted. this will prevent the accidental deletion of CRs that might be needed and also, in the case of uninstall/re-install, keep k8s from losing its mind whenever the CRDs are removed and CRs are present. this latter case usually results in the k8s CP taking a few mins to figure out what's happening and stabilize.