### PR TITLE
PLAT-5844: Explicit Pod Security Contexts

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -34,13 +34,15 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "hephaestus.imagePullSecrets" . | nindent 6 }}
+      {{- include "hephaestus.imagePullSecrets" . | indent 6 }}
       serviceAccountName: {{ include "hephaestus.buildkit.fullname" . }}
       securityContext:
+        runAsNonRoot: {{ .Values.buildkit.rootless }}
+        runAsUser: {{ ternary 1000 0 .Values.buildkit.rootless }}
+        fsGroup: {{ ternary 1000 0 .Values.buildkit.rootless }}
         fsGroupChangePolicy: "OnRootMismatch"
-      {{- if .Values.buildkit.rootless }}
-        fsGroup: 1000
-      {{- end }}
+        seLinuxOptions:
+          type: spc_t
       containers:
         - name: buildkitd
           securityContext:

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -88,6 +88,10 @@ controller:
   # Configure controller pod security context
   podSecurityContext:
     runAsNonRoot: true
+    # nonroot
+    runAsUser: 65532
+    seLinuxOptions:
+      type: spc_t
 
   # Annotations for controller pods
   podAnnotations: {}


### PR DESCRIPTION
All charts must have a pod security context defined. It must include runAsNonRoot, runAsUser and seLinuxOption.