### PR TITLE
PLAT-5844: Allow buildkit groups to runAsAny

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/podsecuritypolicy.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/podsecuritypolicy.yaml
@@ -36,15 +36,9 @@ spec:
   seLinux:
     rule: RunAsAny
   supplementalGroups:
-    rule: MustRunAs
-    ranges:
-      - min: 1
-        max: 65535
+    rule: RunAsAny
   fsGroup:
-    rule: MustRunAs
-    ranges:
-      - min: 1
-        max: 65535
+    rule: RunAsAny
   readOnlyRootFilesystem: false
 
 ---


### PR DESCRIPTION
Given PSPs are going away shortly, simplify the PSP to work in root and rootless mode.
Currently when running as root, the PSP forces the fsGroup is set to 1. Once PSPs go away, the fsGroup will switch to 0.

The current securityContext is setting the fsGroup to match the user id and failing. Rather than play games with the PSP temporarily just allow it to runAsAny which will allow both settings to work.