### PR TITLE
ensure that leased, pending, or running pods are never scaled down during pool reconciliation

### DIFF
--- a/pkg/buildkit/worker/pool_test.go
+++ b/pkg/buildkit/worker/pool_test.go
@@ -965,6 +965,23 @@ func TestPoolPodReconciliation(t *testing.T) {
 			buildRequests:    1,
 			expectedReplicas: 1,
 		},
+		{
+			name: "combo_trim_expired",
+			objects: func() []runtime.Object {
+				leased0 := leasedPod()
+				leased0.Name = "buildkit-0"
+
+				expired1 := validPod()
+				expired1.Name = "buildkit-1"
+				expired1.ObjectMeta.Annotations = map[string]string{
+					expiryTimeAnnotation: time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
+				}
+
+				return []runtime.Object{leased0, expired1}
+			},
+			buildRequests:    0,
+			expectedReplicas: 1,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/buildkit/worker/pool_test.go
+++ b/pkg/buildkit/worker/pool_test.go
@@ -922,7 +922,7 @@ func TestPoolPodReconciliation(t *testing.T) {
 			expectedReplicas: 5,
 		},
 		{
-			name: "combo_embedded_failure_no_growth",
+			name: "combo_embedded_failure_growth",
 			objects: func() []runtime.Object {
 				p0 := pendingPod()
 				p0.Name = "buildkit-0"
@@ -941,7 +941,7 @@ func TestPoolPodReconciliation(t *testing.T) {
 				return []runtime.Object{p0, p1, p2, p3}
 			},
 			buildRequests:    4,
-			expectedReplicas: 4,
+			expectedReplicas: 6,
 		},
 		{
 			name: "combo_embedded_failure_trim",

--- a/pkg/buildkit/worker/pool_test.go
+++ b/pkg/buildkit/worker/pool_test.go
@@ -941,7 +941,7 @@ func TestPoolPodReconciliation(t *testing.T) {
 				return []runtime.Object{p0, p1, p2, p3}
 			},
 			buildRequests:    4,
-			expectedReplicas: 6,
+			expectedReplicas: 4,
 		},
 		{
 			name: "combo_embedded_failure_trim",

--- a/pkg/buildkit/worker/scalearbiter.go
+++ b/pkg/buildkit/worker/scalearbiter.go
@@ -182,6 +182,7 @@ func (a *ScaleArbiter) LeasablePods() (observations []*PodObservation) {
 // DetermineReplicas calculates the number of buildkit replicas required to service the incoming requests.
 func (a *ScaleArbiter) DetermineReplicas(requests int) int {
 	count := 0
+	hasInvalidPods := false
 
 	var output []string
 	for idx, observation := range a.observations {
@@ -195,6 +196,8 @@ func (a *ScaleArbiter) DetermineReplicas(requests int) int {
 			if requests > 0 {
 				requests--
 			}
+		default:
+			hasInvalidPods = true
 		}
 	}
 
@@ -202,7 +205,7 @@ func (a *ScaleArbiter) DetermineReplicas(requests int) int {
 
 	// count is the absolute minimum number of replicas we can set
 	// all current replicas >= count are invalid or expired
-	if len(a.observations)-count > 0 {
+	if hasInvalidPods {
 		// we prioritize removal of invalid pods over servicing of build requests
 		// the build request will be serviced on the next reconciliation loop
 		desiredReplicas = count


### PR DESCRIPTION
27c43734053bc3095972a0c83a5b1d2040bca0de contains the failing test case: a leased pod was removed when only the last expired pod should have been.

193bd27674903861e228c4bbfc484b4fe4c6648b contains a rework of the pool arbitration to ensure that no leased, pending, or running pods are scaled down. only above that minimum number of replicas can we prioritize recycling of expired/invalid pods over serving a new build request.
