### PR TITLE
buildkit statefulset pods are not safe for the cluster-autoscaler to evict

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/buildkit/configmap.yaml") . | sha256sum }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         {{- if .Values.buildkit.rootless }}
         container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
         {{- end }}


### PR DESCRIPTION
When the CA repacks nodes due to underutilization (< 50% by default), it could do so in the middle of an active build. Prevent that by setting `safe-to-evict` to false. An alternative may be to apply this annotation during lease acquisition.