### PR TITLE
Helpers for using rootless with non-default UIDs

### DIFF
--- a/build/buildkit/Dockerfile
+++ b/build/buildkit/Dockerfile
@@ -13,7 +13,8 @@ RUN apk update && \
     apk upgrade && \
     rm -rf /var/cache/apk
 
-RUN deluser user || echo this fails for no reason && \
+# You can ignore "deluser: can't find user in /etc/group"
+RUN deluser user && \
     adduser -u $UID -D user && \
     chown -R user:user /home/user && \
     mkdir -p /run/user/$UID && \

--- a/build/buildkit/Dockerfile
+++ b/build/buildkit/Dockerfile
@@ -7,12 +7,23 @@ RUN apk update && \
 
 FROM moby/buildkit:${BUILDKIT_TAG} AS rootless
 ARG ISTIO_GID=1337
+ARG UID=1000
 USER root
 RUN apk update && \
     apk upgrade && \
     rm -rf /var/cache/apk
+
+RUN deluser user || echo this fails for no reason && \
+    adduser -u $UID -D user && \
+    chown -R user:user /home/user && \
+    mkdir -p /run/user/$UID && \
+    chown user:root /run/user/$UID
+
+ENV XDG_RUNTIME_DIR=/run/user/$UID
+ENV BUILDKIT_HOST=unix:///run/user/$UID/buildkit/buildkitd.sock
+
 RUN addgroup -S -g $ISTIO_GID istio && \
     addgroup user istio && \
     echo user:100000:150000 | tee /etc/subuid | tee /etc/subgid && \
     echo user:$ISTIO_GID:1 >> /etc/subgid
-USER 1000:1000
+USER $UID:$UID

--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -9,7 +9,7 @@ data:
   {{- with .Values.buildkit }}
   buildkitd.toml: |
     [grpc]
-      address = [ "tcp://0.0.0.0:{{ .service.port }}", "{{ .rootless | ternary "unix:///run/user/1000/buildkit/buildkitd.sock" "unix:///run/buildkit/buildkitd.sock" }}" ]
+      address = [ "tcp://0.0.0.0:{{ .service.port }}", "{{ .rootless | ternary (printf "unix:///run/user/%s/buildkit/buildkitd.sock" .rootlessUser) "unix:///run/buildkit/buildkitd.sock" }}" ]
 
       {{- if .mtls.enabled }}
       [grpc.tls]

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -39,8 +39,8 @@ spec:
       serviceAccountName: {{ include "hephaestus.buildkit.fullname" . }}
       securityContext:
         runAsNonRoot: {{ .Values.buildkit.rootless }}
-        runAsUser: {{ ternary 1000 0 .Values.buildkit.rootless }}
-        fsGroup: {{ ternary 1000 0 .Values.buildkit.rootless }}
+        runAsUser: {{ ternary .Values.buildkit.rootlessUser 0 .Values.buildkit.rootless }}
+        fsGroup: {{ ternary .Values.buildkit.rootlessUser 0 .Values.buildkit.rootless }}
         fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
@@ -49,8 +49,8 @@ spec:
           securityContext:
             {{- if .Values.buildkit.rootless }}
             # NOTE: To change UID/GID, you need to rebuild the image
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: {{ .Values.buildkit.rootlessUser }}
+            runAsGroup: {{ .Values.buildkit.rootlessUser }}
             seccompProfile:
               type: Unconfined
             {{- else }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -257,6 +257,10 @@ buildkit:
   # Run buildkit in rootless mode
   rootless: true
 
+  # UID for rootless user in rootless mode
+  # NOTE: You MUST have a custom image if using anything other than 1000
+  rootlessUser: 1000
+
   # Amount of storage GC keeps locally (bytes). This value should be less than the
   # total amount of available persistent storage (e.g. 75% of 20Gi)
   gcKeepStorage: 15000000000


### PR DESCRIPTION
Using other UIDs should not really be recommended, due to the custom image, but in the event that it's necessary (which one organization is speculating it may be for them), this will give some template to follow.