### PR TITLE
cleanup cronjob must support istio during startup

### DIFF
--- a/.github/actions/cloud-image-building/action.yml
+++ b/.github/actions/cloud-image-building/action.yml
@@ -21,9 +21,10 @@ runs:
       shell: bash
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: test/functional/go.mod
+        cache-dependency-path: test/functional/go.sum
 
     - id: go-cache-paths
       name: Gather Go cache paths
@@ -32,22 +33,10 @@ runs:
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Go build cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ hashFiles('test/functional/**/*.go') }}
-
-    - name: Go mod cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ hashFiles('test/functional/go.sum') }}
-
     - name: Install Helm
       uses: azure/setup-helm@v3
       with:
-        version: v3.10.2
+        version: v3.11.2
 
     - name: Run tests
       env:

--- a/.github/actions/push-docker-image/action.yml
+++ b/.github/actions/push-docker-image/action.yml
@@ -22,14 +22,14 @@ runs:
   using: composite
   steps:
     - name: Login to container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
     - id: meta
       name: Extract Docker metadata
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ inputs.registry }}/${{ inputs.repository }}
         tags: |
@@ -39,7 +39,7 @@ runs:
           type=semver,pattern={{major}}.{{minor}}
           type=sha
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         context: .
         push: true

--- a/.github/actions/vendor-docker-image/action.yml
+++ b/.github/actions/vendor-docker-image/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - id: image_source
       name: Extract image details from Helm values
-      uses: mikefarah/yq@v4.25.1
+      uses: mikefarah/yq@v4.33.2
       with:
         cmd: yq '${{ inputs.query }} | .repository + ":" + .tag' deployments/helm/hephaestus/values.yaml
 
@@ -32,18 +32,18 @@ runs:
         fi
         output="$(echo $input | awk -F/ '{print $NF}')"
 
-        echo ::set-output name=source::"$input"
-        echo ::set-output name=destination::"$output"
+        echo "source=$input" >> $GITHUB_OUTPUT
+        echo "destination=$output" >> $GITHUB_OUTPUT
 
     - name: Login to container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
     - name: Tag and push image
-      uses: akhilerm/tag-push-action@v2.0.0
+      uses: akhilerm/tag-push-action@v2.1.0
       with:
         src: ${{ steps.image_fields.outputs.source }}
         dst: quay.io/domino/${{ steps.image_fields.outputs.destination }}

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Update PR Comment
         if: github.event_name != 'pull_request'
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v3
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: rocket
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Authenticate with AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,19 +17,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Cache Go tools
         uses: actions/cache@v3
@@ -61,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - id: docker_push
         name: Push Docker image to GHCR
@@ -88,7 +78,7 @@ jobs:
 
       - id: image_tag
         name: Extract image details from Helm values
-        uses: mikefarah/yq@v4.25.1
+        uses: mikefarah/yq@v4.33.2
         with:
           cmd: yq '.buildkit.image.tag' deployments/helm/hephaestus/values.yaml
 
@@ -103,7 +93,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push rootless Buildkit image to Quay
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           target: rootless
@@ -120,7 +110,7 @@ jobs:
 
       - id: image_tag
         name: Extract image details from Helm values
-        uses: mikefarah/yq@v4.25.1
+        uses: mikefarah/yq@v4.33.2
         with:
           cmd: yq '.buildkit.image.tag' deployments/helm/hephaestus/values.yaml | sed 's/-rootless//'
 
@@ -135,7 +125,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push rootless Buildkit image to Quay
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           target: root
@@ -170,7 +160,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.8.1
+          version: v3.11.2
 
       - id: helm_pkg
         name: Package Helm chart
@@ -183,7 +173,7 @@ jobs:
             semantic_version=$app_version
           fi
           helm package deployments/helm/hephaestus --app-version "$app_version" --version "$semantic_version"
-          echo ::set-output name=artifact::"hephaestus-${semantic_version}.tgz"
+          echo "artifact=hephaestus-${semantic_version}.tgz" >> $GITHUB_OUTPUT
 
       - name: Push Helm chart to GHCR
         uses: ./.github/actions/push-helm-chart
@@ -214,12 +204,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Install KinD
         uses: engineerd/setup-kind@v0.5.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,7 @@ jobs:
 
       - id: buildkit_tag
         name: Extract image tag from Helm values
-        uses: mikefarah/yq@v4.28.2
+        uses: mikefarah/yq@v4.33.2
         with:
           cmd: test -n "${{ inputs.buildkitVersion }}" && echo "${{ inputs.buildkitVersion }}" || yq '.buildkit.image.tag' deployments/helm/hephaestus/values.yaml | sed 's/-rootless//'
 
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push image to Quay
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           target: root
@@ -96,7 +96,7 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Build and push image to Quay
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           target: rootless

--- a/deployments/helm/hephaestus/templates/controller/cronjob.yaml
+++ b/deployments/helm/hephaestus/templates/controller/cronjob.yaml
@@ -50,6 +50,9 @@ spec:
                 - run-gc
                 - --maxIBRetention={{ .Values.controller.completedImageBuildCleanup.retainMax | int }}
                 - --config=/etc/hephaestus/config.yaml
+                {{- if .Values.istio.enabled }}
+                - --istio-enabled
+                {{- end }}
               {{- with .Values.controller.manager }}
               {{- if or .extraEnvVars $.Values.podEnv }}
               env:

--- a/pkg/cmd/controller/root.go
+++ b/pkg/cmd/controller/root.go
@@ -53,6 +53,7 @@ func newStartCommand() *cobra.Command {
 }
 
 func newRunGCCommand() *cobra.Command {
+	var istioEnabled bool
 	cmd := &cobra.Command{
 		Use:   "run-gc",
 		Short: "Runs the image builder automatic cleanup",
@@ -74,9 +75,10 @@ func newRunGCCommand() *cobra.Command {
 				return err
 			}
 
-			return controller.RunGC(maxIBRetention, cfg.Manager)
+			return controller.RunGC(maxIBRetention, cfg.Manager, istioEnabled)
 		},
 	}
+	cmd.PersistentFlags().BoolVar(&istioEnabled, "istio-enabled", false, "Enable support for Istio sidecar container")
 	cmd.Flags().Int("maxIBRetention", 5, "Delete all ContainerImageBuild resources in a 'finished' "+
 		"state that exceed this count, we will retain the newest builds.")
 	return cmd

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -75,7 +75,7 @@ func Exists(gv metav1.GroupVersion) (bool, error) {
 // operate will read all available CRDS and apply state changes to the cluster using the processor func.
 func operate(ctx context.Context, processor crdProcessor, istio bool) error {
 	if istio {
-		quit, err := waitForIstioSidecar()
+		quit, err := kubernetes.WaitForIstioSidecar(log)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubernetes/istio.go
+++ b/pkg/kubernetes/istio.go
@@ -1,8 +1,9 @@
-package crd
+package kubernetes
 
 import (
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
@@ -13,18 +14,18 @@ const (
 
 var retryClient *retryablehttp.Client
 
-func waitForIstioSidecar() (func(), error) {
-	log.Info("Checking istio sidecar")
+func WaitForIstioSidecar(logger logr.Logger) (func(), error) {
+	logger.Info("Checking istio sidecar")
 	resp, err := retryClient.Head(checkURL)
 	if err != nil {
-		log.Error(err, "Istio sidecar is not ready")
+		logger.Error(err, "Istio sidecar is not ready")
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	log.Info("Istio sidecar available")
+	logger.Info("Istio sidecar available")
 	fn := func() {
-		log.Info("Triggering istio termination")
+		logger.Info("Triggering istio termination")
 		_, _ = retryClient.Post(finishURL, "", nil)
 	}
 

--- a/test/functional/go.mod
+++ b/test/functional/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.12.0
 	github.com/dominodatalab/hephaestus v0.1.26
-	github.com/dominodatalab/testenv v0.0.0-20221118170829-a1ed846e2c41
+	github.com/dominodatalab/testenv v0.0.0-20230410204657-bd9fc700408f
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/go-redis/redis/v9 v9.0.0-rc.1
 	github.com/google/go-containerregistry v0.12.1

--- a/test/functional/go.sum
+++ b/test/functional/go.sum
@@ -294,8 +294,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dominodatalab/testenv v0.0.0-20221118170829-a1ed846e2c41 h1:QmbvExxDCtl4Tt/xyEbzag34Hd6nC8nrbakYlRNJPoI=
-github.com/dominodatalab/testenv v0.0.0-20221118170829-a1ed846e2c41/go.mod h1:S6ua68CDPVyaj249bsb4X+ObGr6zjiv23m767hHdFKQ=
+github.com/dominodatalab/testenv v0.0.0-20230410204657-bd9fc700408f h1:Rho4qFJM/VaO8r7ih5sLNKogiunk5he+S+91byymcLE=
+github.com/dominodatalab/testenv v0.0.0-20230410204657-bd9fc700408f/go.mod h1:S6ua68CDPVyaj249bsb4X+ObGr6zjiv23m767hHdFKQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=


### PR DESCRIPTION
To properly work with Istio, the cronjob must be able to wait for the proxy sidecar to start and then call `/quitquitquit` at exit.