### PR TITLE
PLAT-6592: certificate issuer based on buildkit ns

### DIFF
--- a/deployments/helm/hephaestus/templates/_helpers.tpl
+++ b/deployments/helm/hephaestus/templates/_helpers.tpl
@@ -165,13 +165,6 @@ Return the buildkit fully-qualified app name.
 {{- end }}
 
 {{/*
-Return the namespace for buildkit-related resources.
-*/}}
-{{- define "hephaestus.buildkit.namespace" -}}
-{{- .Values.buildkit.namespace | default .Release.Namespace }}
-{{- end }}
-
-{{/*
 Return the buildkit standard labels.
 */}}
 {{- define "hephaestus.buildkit.labels.standard" -}}

--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
-  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 data:

--- a/deployments/helm/hephaestus/templates/buildkit/networkpolicy.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/networkpolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
-  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 spec:
@@ -20,18 +19,4 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "hephaestus.controller.labels.matchLabels" . | nindent 14 }}
-          {{- if ne (include "hephaestus.buildkit.namespace" .) .Release.Namespace }}
-          namespaceSelector:
-            matchLabels:
-              {{- /*
-                https://github.com/databus23/helm-diff/issues/263 prevents us from doing a "lookup" here and defaulting
-                to the release namespace labels. once that is resolved we can remove the following garbage and replace
-                it with "{{- .Values.buildkit.releaseNamespaceLabels | default (lookup "v1" "Namespace" "" .Release.Namespace).metadata.labels | toYaml | nindent 14 }}"
-              */}}
-              {{- if empty .Values.buildkit.releaseNamespaceLabels }}
-              {{- fail ".Values.buildkit.releaseNamespaceLabels cannot be empty when deploying buildkit into a separate namespace!" }}
-              {{- else }}
-              {{- .Values.buildkit.releaseNamespaceLabels | toYaml | nindent 14 }}
-              {{- end }}
-          {{- end }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/podsecuritypolicy.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/podsecuritypolicy.yaml
@@ -68,5 +68,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "hephaestus.buildkit.serviceAccountName" . }}
-    namespace: {{ include "hephaestus.buildkit.namespace" . }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/service.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
-  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 spec:

--- a/deployments/helm/hephaestus/templates/buildkit/serviceaccount.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/serviceaccount.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "hephaestus.buildkit.serviceAccountName" . }}
-  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
   {{- with .Values.buildkit.serviceAccount.annotations }}

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}
-  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 spec:

--- a/deployments/helm/hephaestus/templates/certificates.yaml
+++ b/deployments/helm/hephaestus/templates/certificates.yaml
@@ -1,5 +1,6 @@
+{{- $issuerKind := ternary "Issuer" "ClusterIssuer" (eq .Values.certManagerNamespace (include "hephaestus.buildkit.namespace" .)) }}
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: {{ $issuerKind }}
 metadata:
   name: {{ include "hephaestus.certmanager.selfSignedIssuer" . }}
   labels:
@@ -24,12 +25,12 @@ spec:
     size: 256
   issuerRef:
     group: cert-manager.io
-    kind: ClusterIssuer
+    kind: {{ $issuerKind }}
     name: {{ include "hephaestus.certmanager.selfSignedIssuer" . }}
 
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: {{ $issuerKind }}
 metadata:
   name: {{ include "hephaestus.certmanager.caIssuer" . }}
   labels:
@@ -50,7 +51,7 @@ spec:
     - {{ include "hephaestus.webhook.service" . }}.{{ .Release.Namespace }}.svc
     - {{ include "hephaestus.webhook.service" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
-    kind: ClusterIssuer
+    kind: {{ $issuerKind }}
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.webhook.secret" . }}
 
@@ -67,7 +68,7 @@ spec:
   usages:
     - client auth
   issuerRef:
-    kind: ClusterIssuer
+    kind: {{ $issuerKind }}
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.clientSecret" . }}
 
@@ -86,7 +87,7 @@ spec:
   usages:
     - server auth
   issuerRef:
-    kind: ClusterIssuer
+    kind: {{ $issuerKind }} 
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.serverSecret" . }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/certificates.yaml
+++ b/deployments/helm/hephaestus/templates/certificates.yaml
@@ -1,6 +1,5 @@
-{{- $issuerKind := ternary "Issuer" "ClusterIssuer" (eq .Values.certManagerNamespace (include "hephaestus.buildkit.namespace" .)) }}
 apiVersion: cert-manager.io/v1
-kind: {{ $issuerKind }}
+kind: Issuer
 metadata:
   name: {{ include "hephaestus.certmanager.selfSignedIssuer" . }}
   labels:
@@ -13,7 +12,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "hephaestus.certmanager.selfSignedCA" . }}
-  namespace: {{ .Values.certManagerNamespace }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
@@ -25,12 +23,12 @@ spec:
     size: 256
   issuerRef:
     group: cert-manager.io
-    kind: {{ $issuerKind }}
+    kind: Issuer
     name: {{ include "hephaestus.certmanager.selfSignedIssuer" . }}
 
 ---
 apiVersion: cert-manager.io/v1
-kind: {{ $issuerKind }}
+kind: Issuer
 metadata:
   name: {{ include "hephaestus.certmanager.caIssuer" . }}
   labels:
@@ -51,7 +49,7 @@ spec:
     - {{ include "hephaestus.webhook.service" . }}.{{ .Release.Namespace }}.svc
     - {{ include "hephaestus.webhook.service" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
-    kind: {{ $issuerKind }}
+    kind: Issuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.webhook.secret" . }}
 
@@ -68,7 +66,7 @@ spec:
   usages:
     - client auth
   issuerRef:
-    kind: {{ $issuerKind }}
+    kind: Issuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.clientSecret" . }}
 
@@ -77,17 +75,16 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "hephaestus.buildkit.fullname" . }}-server
-  namespace: {{ include "hephaestus.buildkit.namespace" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   dnsNames:
     - "*.{{ include "hephaestus.buildkit.fullname" . }}"
-    - "*.{{ include "hephaestus.buildkit.fullname" . }}.{{ include "hephaestus.buildkit.namespace" . }}"
+    - "*.{{ include "hephaestus.buildkit.fullname" . }}.{{ .Release.Namespace }}"
   usages:
     - server auth
   issuerRef:
-    kind: {{ $issuerKind }} 
+    kind: Issuer
     name: {{ include "hephaestus.certmanager.caIssuer" . }}
   secretName: {{ include "hephaestus.buildkit.serverSecret" . }}
 {{- end }}

--- a/deployments/helm/hephaestus/templates/controller/secret.yaml
+++ b/deployments/helm/hephaestus/templates/controller/secret.yaml
@@ -16,7 +16,7 @@ stringData:
         {{- .labels | toYaml | nindent 8 }}
       {{- end }}
     buildkit:
-      namespace: {{ include "hephaestus.buildkit.namespace" . }}
+      namespace: {{ .Release.Namespace }}
       daemonPort: {{ .Values.buildkit.service.port }}
       serviceName: {{ include "hephaestus.buildkit.fullname" . }}
       statefulSetName: {{ include "hephaestus.buildkit.fullname" . }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -23,10 +23,6 @@ enableNetworkPolicies: true
 # This flag will have no effect in k8s >= 1.25.
 enablePodSecurityPolicies: false
 
-# Namespace where cert-manager is deployed. CA certificate secret needs to live in the cluster resource namespace.
-# https://cert-manager.io/docs/faq/cluster-resource/
-certManagerNamespace: cert-manager
-
 # Applied to all pods
 podAnnotations: {}
 podLabels: {}
@@ -276,14 +272,6 @@ buildkit:
   # Add a ConfigMap containing custom CAs if you need to push images to one or
   # more registries that use self-signed certificates
   customCABundle: ""
-
-  # Deploy buildkit workload into a different namespace from the release
-  namespace: ""
-
-  # The buildkit network policy will select against all the labels on the
-  # release namespace to allow ingress traffic from the controller by default.
-  # Use this field to limit the selector labels
-  releaseNamespaceLabels: {}
 
   # Buildkit image
   image:


### PR DESCRIPTION
If the buildkit is in the same namespace as the controller, use Issuers instead of ClusterIssuers.