### PR TITLE
Bump CI helm 3.11.2 -> 3.12.0

### DIFF
--- a/.github/actions/cloud-image-building/action.yml
+++ b/.github/actions/cloud-image-building/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install Helm
       uses: azure/setup-helm@v3
       with:
-        version: v3.11.2
+        version: v3.12.0
 
     - name: Run tests
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.11.2
+          version: v3.12.0
 
       - id: helm_pkg
         name: Package Helm chart


### PR DESCRIPTION
 - In addition to other features, this updates OCI annotations on pushed Helm charts to support better interop with other tools

   https://github.com/helm/helm/releases/tag/v3.12.0