### PR TITLE
rootless causes invalid buildkitd mount path to be used

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -8,7 +8,7 @@ data:
   {{- with .Values.buildkit }}
   buildkitd.toml: |
     [grpc]
-      address = [ "tcp://0.0.0.0:{{ .service.port }}", "{{ .rootless | ternary (printf "unix:///run/user/%s/buildkit/buildkitd.sock" .rootlessUser) "unix:///run/buildkit/buildkitd.sock" }}" ]
+      address = [ "tcp://0.0.0.0:{{ .service.port }}", "{{ .rootless | ternary (printf "unix:///run/user/%v/buildkit/buildkitd.sock" .rootlessUser) "unix:///run/buildkit/buildkitd.sock" }}" ]
 
       {{- if .mtls.enabled }}
       [grpc.tls]


### PR DESCRIPTION
The error looked like this:
```
time="2023-07-17T19:20:12Z" level=warning msg="currently, only the default worker can be used."
time="2023-07-17T19:20:12Z" level=warning msg="TLS is disabled for unix:///run/user/%!s(float64=1000)/buildkit/buildkitd.sock"
buildkitd: mkdir /run/user/%!s(float64=1000): permission denied
[rootlesskit:child ] error: command [buildkitd --config /etc/buildkit/buildkitd.toml] exited: exit status 1
[rootlesskit:parent] error: child exited: exit status 1
```


Before:
```
$ helm template . -s templates/buildkit/configmap.yaml
[snip]
address = [ "tcp://0.0.0.0:1234", "unix:///run/user/%!s(float64=1000)/buildkit/buildkitd.sock" ]

$ helm template . -s templates/buildkit/configmap.yaml --set buildkit.rootlessUser=1234
[snip]
address = [ "tcp://0.0.0.0:1234", "unix:///run/user/%!s(int64=1234)/buildkit/buildkitd.sock" ]
```

After:
```
$ helm template . -s templates/buildkit/configmap.yaml
[snip]
address = [ "tcp://0.0.0.0:1234", "unix:///run/user/1000/buildkit/buildkitd.sock" ]

$ helm template . -s templates/buildkit/configmap.yaml --set buildkit.rootlessUser=1234
[snip]
address = [ "tcp://0.0.0.0:1234", "unix:///run/user/1234/buildkit/buildkitd.sock" ]
```