### PR TITLE
add a deadline to cloud client registration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
   vendor-buildkit-rootless:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -104,6 +105,7 @@ jobs:
   vendor-buildkit:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -136,6 +138,7 @@ jobs:
   vendor-vector:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -149,10 +152,7 @@ jobs:
 
   helm:
     runs-on: ubuntu-latest
-    needs:
-      - docker
-      - vendor-buildkit
-      - vendor-vector
+    needs: build
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
 
   helm:
     runs-on: ubuntu-latest
-    needs: build
+    needs: docker
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/config v1.19.0
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.13
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.20.2
+	github.com/aws/smithy-go v1.15.0
 	github.com/containerd/console v1.0.3
 	github.com/distribution/reference v0.5.0
 	github.com/docker/cli v24.0.6+incompatible
@@ -64,7 +66,6 @@ require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/avast/retry-go/v4 v4.3.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.43 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.13 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45 // indirect
@@ -72,7 +73,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.15.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.17.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.23.2 // indirect
-	github.com/aws/smithy-go v1.15.0 // indirect
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/pkg/controller/start.go
+++ b/pkg/controller/start.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -81,7 +80,7 @@ func Start(cfg config.Controller) error {
 	ctx, cancel := context.WithTimeout(context.Background(), cloudAuthRegistrationTimeout)
 	defer cancel()
 
-	log.Info(fmt.Sprintf("Registering cloud auth providers with %s timeout", cloudAuthRegistrationTimeout))
+	log.Info("Registering cloud auth providers", "timeout", cloudAuthRegistrationTimeout)
 	if err = credentials.LoadCloudProviders(ctx, log); err != nil {
 		return err
 	}

--- a/pkg/controller/start.go
+++ b/pkg/controller/start.go
@@ -67,7 +67,7 @@ func Start(cfg config.Controller) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	log.Info("Registering cloud auth providers")

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -44,10 +44,10 @@ var (
 	urlRegex = regexp.MustCompile(
 		`^(?P<aws_account_id>[a-zA-Z\d][a-zA-Z\d-_]*)\.dkr\.ecr(-fips)?\.([a-zA-Z\d][a-zA-Z\d-_]*)\.amazonaws\.com(\.cn)?`,
 	)
-	clientMode = aws.LogRequest | aws.LogResponse | aws.LogRetries
 )
 
 func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Registry) error {
+	clientMode := aws.LogRequest | aws.LogResponse | aws.LogRetries
 	clientLogger := &awsLogger{logger}
 	awsConfig, err := config.LoadDefaultConfig(
 		ctx,

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/smithy-go/logging"
 	"github.com/docker/docker/api/types/registry"
-	"github.com/go-logr/logr"
-
 	"github.com/dominodatalab/hephaestus/pkg/controller/support/credentials/cloudauth"
+	"github.com/go-logr/logr"
 )
 
 type ecrClient interface {
@@ -25,21 +26,46 @@ type ecrClient interface {
 	) (*ecr.GetAuthorizationTokenOutput, error)
 }
 
+type awsLogger struct {
+	logr.Logger
+}
+
+func (l awsLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
+	var level int
+	if classification == logging.Debug {
+		level = 1
+	}
+
+	l.V(level).Info(fmt.Sprintf(format, v...))
+}
+
 var (
 	client   ecrClient
 	urlRegex = regexp.MustCompile(
 		`^(?P<aws_account_id>[a-zA-Z\d][a-zA-Z\d-_]*)\.dkr\.ecr(-fips)?\.([a-zA-Z\d][a-zA-Z\d-_]*)\.amazonaws\.com(\.cn)?`,
 	)
+	clientMode = aws.LogRequest | aws.LogResponse | aws.LogRetries
 )
 
 func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Registry) error {
-	config, err := config.LoadDefaultConfig(ctx, config.WithEC2IMDSRegion())
+	clientLogger := &awsLogger{logger}
+	awsConfig, err := config.LoadDefaultConfig(
+		ctx,
+		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
+			o.Client = imds.New(imds.Options{
+				ClientLogMode: clientMode,
+				Logger:        clientLogger,
+			})
+		}),
+		config.WithLogger(clientLogger),
+		config.WithClientLogMode(clientMode),
+	)
 	if err != nil {
 		logger.Info("ECR not registered", "error", err)
 		return nil
 	}
 
-	client = ecr.NewFromConfig(config)
+	client = ecr.NewFromConfig(awsConfig)
 
 	registry.Register(urlRegex, authenticate)
 	logger.Info("ECR registered")


### PR DESCRIPTION
In AWS, it can take longer than the default to register a client
because of IMDS. By setting a deadline, we override the default
timeout.  Adds debug logging to the AWS client.

Having a built-in env var for this is still pending: https://github.com/aws/aws-sdk-go/issues/3495.