### PR TITLE
support cross-region ECR authentication

### DIFF
--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -43,6 +43,7 @@ var (
 	awsConfig aws.Config
 	newClient = newECRClient
 	urlRegex  = regexp.MustCompile(
+		//nolint:lll
 		`^(?P<aws_account_id>[a-zA-Z\d][a-zA-Z\d-_]*)\.dkr\.ecr(-fips)?\.(?P<region>[a-zA-Z\d][a-zA-Z\d-_]*)\.amazonaws\.com(\.cn)?`,
 	)
 	urlRegexRegionIndex = urlRegex.SubexpIndex("region")

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -75,7 +75,7 @@ func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Regis
 }
 
 func newECRClient(region string) ecrClient {
-	c := awsConfig.Copy()
+	c := awsConfig
 	c.Region = region
 	return ecr.NewFromConfig(c)
 }

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -40,16 +40,20 @@ func (l awsLogger) Logf(classification logging.Classification, format string, v 
 }
 
 var (
-	client   ecrClient
-	urlRegex = regexp.MustCompile(
-		`^(?P<aws_account_id>[a-zA-Z\d][a-zA-Z\d-_]*)\.dkr\.ecr(-fips)?\.([a-zA-Z\d][a-zA-Z\d-_]*)\.amazonaws\.com(\.cn)?`,
+	awsConfig aws.Config
+	newClient = newECRClient
+	urlRegex  = regexp.MustCompile(
+		`^(?P<aws_account_id>[a-zA-Z\d][a-zA-Z\d-_]*)\.dkr\.ecr(-fips)?\.(?P<region>[a-zA-Z\d][a-zA-Z\d-_]*)\.amazonaws\.com(\.cn)?`,
 	)
+	urlRegexRegionIndex = urlRegex.SubexpIndex("region")
 )
 
 func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Registry) error {
 	clientMode := aws.LogRequest | aws.LogResponse | aws.LogRetries
 	clientLogger := &awsLogger{logger}
-	awsConfig, err := config.LoadDefaultConfig(
+
+	var err error
+	awsConfig, err = config.LoadDefaultConfig(
 		ctx,
 		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
 			o.Client = imds.New(imds.Options{
@@ -65,21 +69,28 @@ func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Regis
 		return nil
 	}
 
-	client = ecr.NewFromConfig(awsConfig)
-
 	registry.Register(urlRegex, authenticate)
 	logger.Info("ECR registered")
 	return nil
 }
 
+func newECRClient(region string) ecrClient {
+	c := awsConfig.Copy()
+	c.Region = region
+	return ecr.NewFromConfig(c)
+}
+
 func authenticate(ctx context.Context, logger logr.Logger, url string) (*registry.AuthConfig, error) {
 	logger.WithName("ecr-auth-provider")
 
-	if !urlRegex.MatchString(url) {
+	match := urlRegex.FindStringSubmatch(url)
+	if len(match) == 0 {
 		err := fmt.Errorf("ECR URL is invalid: %q should match pattern %v", url, urlRegex)
 		logger.Info(err.Error())
 		return nil, err
 	}
+
+	client := newClient(match[urlRegexRegionIndex])
 	input := &ecr.GetAuthorizationTokenInput{}
 
 	resp, err := client.GetAuthorizationToken(ctx, input)

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr_test.go
@@ -157,7 +157,9 @@ func TestAuthenticate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			client = &tt.client
+			newClient = func(region string) ecrClient {
+				return &tt.client
+			}
 			authConfig, err := authenticate(defaultCtx, log, tt.serverUrl)
 
 			// Compare expected error condition.

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr_test.go
@@ -24,6 +24,11 @@ func TestAuthenticate(t *testing.T) {
 	log := zapr.NewLogger(zap.New(observerCore))
 
 	validToken := "YWJjOmhp"
+	validTokenOutput := &ecr.GetAuthorizationTokenOutput{
+		AuthorizationData: []ecrTypes.AuthorizationData{
+			{AuthorizationToken: &validToken},
+		},
+	}
 
 	// expected errors
 	invalidServerErr := fmt.Errorf("ECR URL is invalid: \"0123456789012.dkr.ecr.us-west-2.amazonaws.io\" should match pattern %v", urlRegex)
@@ -42,6 +47,7 @@ func TestAuthenticate(t *testing.T) {
 		authConfig         *registry.AuthConfig
 		expectedLogMessage string
 		expectedError      error
+		expectedRegion     string
 	}{
 		{
 			name:               "invalid_server",
@@ -111,11 +117,7 @@ func TestAuthenticate(t *testing.T) {
 			name:      "success_server.com",
 			serverUrl: "0123456789012.dkr.ecr.us-west-2.amazonaws.com",
 			client: fakeECRClient{
-				TokenOutput: &ecr.GetAuthorizationTokenOutput{
-					AuthorizationData: []ecrTypes.AuthorizationData{
-						{AuthorizationToken: &validToken},
-					},
-				},
+				TokenOutput: validTokenOutput,
 			},
 			authConfig: &registry.AuthConfig{
 				Username: "abc",
@@ -126,13 +128,7 @@ func TestAuthenticate(t *testing.T) {
 		{
 			name:      "success_server.com.cn",
 			serverUrl: "0123456789012.dkr.ecr.us-west-2.amazonaws.com.cn",
-			client: fakeECRClient{
-				TokenOutput: &ecr.GetAuthorizationTokenOutput{
-					AuthorizationData: []ecrTypes.AuthorizationData{
-						{AuthorizationToken: &validToken},
-					},
-				},
-			},
+			client:    fakeECRClient{TokenOutput: validTokenOutput},
 			authConfig: &registry.AuthConfig{
 				Username: "abc",
 				Password: "hi",
@@ -142,22 +138,24 @@ func TestAuthenticate(t *testing.T) {
 		{
 			name:      "success_server.fips",
 			serverUrl: "0123456789012.dkr.ecr-fips.us-west-2.amazonaws.com",
-			client: fakeECRClient{
-				TokenOutput: &ecr.GetAuthorizationTokenOutput{
-					AuthorizationData: []ecrTypes.AuthorizationData{
-						{AuthorizationToken: &validToken},
-					},
-				},
-			},
+			client:    fakeECRClient{TokenOutput: validTokenOutput},
 			authConfig: &registry.AuthConfig{
 				Username: "abc",
 				Password: "hi",
 			},
 			expectedLogMessage: successMsg,
 		},
+		{
+			name:               "success_server.new_region",
+			serverUrl:          "0123456789012.dkr.ecr.us-east-1.amazonaws.com",
+			client:             fakeECRClient{TokenOutput: validTokenOutput},
+			expectedRegion:     "us-east-1",
+			expectedLogMessage: successMsg,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			newClient = func(region string) ecrClient {
+				tt.client.region = region
 				return &tt.client
 			}
 			authConfig, err := authenticate(defaultCtx, log, tt.serverUrl)
@@ -168,6 +166,10 @@ func TestAuthenticate(t *testing.T) {
 			} else {
 				require.Error(t, err)
 				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			}
+
+			if tt.expectedRegion != "" {
+				assert.Equal(t, tt.expectedRegion, tt.client.region)
 			}
 
 			reflect.DeepEqual(tt.authConfig, authConfig)
@@ -184,6 +186,7 @@ func TestAuthenticate(t *testing.T) {
 type fakeECRClient struct {
 	errOut      bool
 	TokenOutput *ecr.GetAuthorizationTokenOutput
+	region      string
 }
 
 func (f *fakeECRClient) GetAuthorizationToken(


### PR DESCRIPTION
When accessing an ECR repo cross-region, we need to configure the ECR client with credentials from that region.