### PR TITLE
deprecate explicit cloud provider config for pull registries and retry credential verification

### DIFF
--- a/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
@@ -104,6 +104,10 @@ spec:
                           type: string
                       type: object
                     cloudProvided:
+                      description: 'NOTE: this field was previously used to determine
+                        whether to fetch credentials from the cloud a given server.
+                        this is now done automatically and this field is no longer
+                        necessary.'
                       type: boolean
                     secret:
                       properties:

--- a/deployments/crds/hephaestus.dominodatalab.com_imagecaches.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagecaches.yaml
@@ -67,6 +67,10 @@ spec:
                           type: string
                       type: object
                     cloudProvided:
+                      description: 'NOTE: this field was previously used to determine
+                        whether to fetch credentials from the cloud a given server.
+                        this is now done automatically and this field is no longer
+                        necessary.'
                       type: boolean
                     secret:
                       properties:

--- a/pkg/api/hephaestus/v1/types.go
+++ b/pkg/api/hephaestus/v1/types.go
@@ -53,9 +53,12 @@ type RegistryCredentials struct {
 	//  credential types.
 	Server string `json:"server,omitempty"`
 
-	CloudProvided *bool                 `json:"cloudProvided,omitempty"`
-	BasicAuth     *BasicAuthCredentials `json:"basicAuth,omitempty"`
-	Secret        *SecretCredentials    `json:"secret,omitempty"`
+	// NOTE: this field was previously used to determine whether to fetch credentials from the cloud a given server.
+	// this is now done automatically and this field is no longer necessary.
+	CloudProvided *bool `json:"cloudProvided,omitempty"`
+
+	BasicAuth *BasicAuthCredentials `json:"basicAuth,omitempty"`
+	Secret    *SecretCredentials    `json:"secret,omitempty"`
 }
 
 type SecretReference struct {

--- a/pkg/api/hephaestus/v1/validations.go
+++ b/pkg/api/hephaestus/v1/validations.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func validateImages(log logr.Logger, fp *field.Path, images []string) (errs field.ErrorList) {
@@ -41,9 +40,8 @@ func validateRegistryAuth(log logr.Logger, fp *field.Path, registryAuth []Regist
 
 		ba := auth.BasicAuth != nil
 		sa := auth.Secret != nil
-		ca := ptr.Deref(auth.CloudProvided, false)
 
-		if (ba && sa) || (ba && ca) || (sa && ca) {
+		if ba && sa {
 			log.V(1).Info("Multiple registry credential sources provided")
 			errs = append(errs, field.Forbidden(fp, "cannot specify more than 1 credential source"))
 
@@ -69,11 +67,8 @@ func validateRegistryAuth(log logr.Logger, fp *field.Path, registryAuth []Regist
 				log.V(1).Info("Registry credentials secret namespace is missing")
 				errs = append(errs, field.Required(fp.Child("secret", "namespace"), "must not be blank"))
 			}
-		case ca:
-			log.V(1).Info("Registry credential using cloud provided authentication")
 		default:
 			log.V(1).Info("No registry credential sources provided")
-			errs = append(errs, field.Required(fp, "must specify 1 credential source"))
 		}
 	}
 

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -110,9 +110,9 @@ func Persist(
 			pac, err := CloudAuthRegistry.RetrieveAuthorization(ctx, logger, cred.Server)
 			if err != nil {
 				if err != cloudauth.ErrNoLoader {
-					return "", nil, fmt.Errorf("cloud registry authorization failed: %w", err)
+					return "", nil, fmt.Errorf("registry authorization failed: %w", err)
 				}
-				return "", nil, fmt.Errorf("credential %v is missing auth section", cred)
+				return "", nil, fmt.Errorf("failed to authorize server %s, credentials may be misconfigured", cred.Server)
 			}
 
 			ac = *pac

--- a/test/functional/aks_test.go
+++ b/test/functional/aks_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/utils/pointer"
 )
 
 func TestAKSFunctionality(t *testing.T) {
@@ -73,8 +72,7 @@ func (suite *AKSTestSuite) testCloudAuth(ctx context.Context, t *testing.T) {
 		python39JupyterBuildContext,
 		image,
 		&hephv1.RegistryCredentials{
-			Server:        cloudRegistry,
-			CloudProvided: pointer.Bool(true),
+			Server: cloudRegistry,
 		},
 	)
 	ib := createBuild(t, ctx, suite.hephClient, build)

--- a/test/functional/eks_test.go
+++ b/test/functional/eks_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/utils/pointer"
 )
 
 func TestEKSFunctionality(t *testing.T) {
@@ -55,8 +54,7 @@ func (suite *EKSTestSuite) testCloudAuth(ctx context.Context, t *testing.T) {
 		python39JupyterBuildContext,
 		canonicalImage,
 		&hephv1.RegistryCredentials{
-			Server:        cloudRegistry,
-			CloudProvided: pointer.Bool(true),
+			Server: cloudRegistry,
 		},
 	)
 	ib := createBuild(t, ctx, suite.hephClient, build)

--- a/test/functional/gke_test.go
+++ b/test/functional/gke_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	auth "golang.org/x/oauth2/google"
-	"k8s.io/utils/pointer"
 )
 
 func TestGKEFunctionality(t *testing.T) {
@@ -66,8 +65,7 @@ func (suite *GKETestSuite) testCloudAuth(ctx context.Context, t *testing.T) {
 		python39JupyterBuildContext,
 		fmt.Sprintf("%s/%s", cloudRegistry, image),
 		&hephv1.RegistryCredentials{
-			Server:        cloudRegistry,
-			CloudProvided: pointer.Bool(true),
+			Server: cloudRegistry,
 		},
 	)
 	ib := createBuild(t, ctx, suite.hephClient, build)


### PR DESCRIPTION
Cloud provider specification isn't necessary as we can either take the explicit secrets being passed or use a regex to attempt a cloud login.