### PR TITLE
allow pool release to complete with canceled build

### DIFF
--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -189,7 +189,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 
 	defer func(pool worker.Pool, endpoint string) {
 		log.Info("Releasing buildkit worker", "endpoint", endpoint)
-		if err := pool.Release(buildCtx, endpoint); err != nil {
+		if err := pool.Release(coreCtx, endpoint); err != nil {
 			log.Error(err, "Failed to release pool endpoint", "endpoint", endpoint)
 		} else {
 			log.Info("Buildkit worker released")


### PR DESCRIPTION
Looks like a minor translation error in https://github.com/dominodatalab/hephaestus/pull/126/files#diff-858da12a46ea7b374d3935c612faa944aec57f6d6e118bf800e74b1927ce3313R187. If `buildCtx` is canceled, then the K8s queries in `Release()` will not be run:
```
2024-04-24T08:18:57.037537984Z	ERROR	controller.imagebuild.component.build-dispatcher	Failed to release pool endpoint	{"imagebuild": {"name":"domino-build-6628bf0800dc946cf27f6f4b","namespace":"domino-compute"}, "endpoint": "tcp://hephaestus-buildkit-0.hephaestus-buildkit.domino-compute:1234", "error": "client rate limiter Wait returned an error: context canceled"}
```