### PR TITLE
Define rootless/non-rootless image tags separately

### DIFF
--- a/deployments/helm/hephaestus/templates/_helpers.tpl
+++ b/deployments/helm/hephaestus/templates/_helpers.tpl
@@ -52,7 +52,7 @@ Return the controller service account name.
 Returns a unified list of image pull secrets.
 */}}
 {{- define "hephaestus.imagePullSecrets" -}}
-{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.controller.manager.image .Values.controller.vector.image .Values.buildkit.image) "context" $) }}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.controller.manager.image .Values.controller.vector.image .Values.buildkit.image .Values.buildkit.rootlessImage) "context" $) }}
 {{- end }}
 
 {{/*
@@ -189,13 +189,11 @@ Return the buildkit mtls server secret name.
 Return the buildkit image name.
 */}}
 {{- define "hephaestus.buildkit.image" -}}
-{{- $imageRoot := .Values.buildkit.image }}
-{{- $tag := .Values.buildkit.image.tag | default .Chart.AppVersion }}
-{{- if not .Values.buildkit.rootless }}
-{{- $tag = replace "-rootless" "" $tag }}
+{{- if .Values.buildkit.rootless }}
+{{- include "common.images.image" (dict "imageRoot" .Values.buildkit.rootlessImage "global" $) }}
+{{- else }}
+{{- include "common.images.image" (dict "imageRoot" .Values.buildkit.image "global" $) }}
 {{- end }}
-{{- $_ := set $imageRoot "tag" $tag }}
-{{- include "common.images.image" (dict "imageRoot" $imageRoot "global" $) }}
 {{- end }}
 
 {{/*

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -273,6 +273,14 @@ buildkit:
   image:
     registry: ""
     repository: moby/buildkit
+    tag: v0.16.0
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+
+  # Buildkit image
+  rootlessImage:
+    registry: ""
+    repository: moby/buildkit
     tag: v0.16.0-rootless
     pullPolicy: IfNotPresent
     pullSecrets: []


### PR DESCRIPTION
We currently default to the rootless buildkit image as the only image in the config, and then life-mutate the image tag to what we presume the non-rootless one would be based on a string substitution.

Let's just clearly define the two images and pick the appropriate one.