### PR TITLE
Update buildkit CI after buildkit helm chart image change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         name: Extract image details from Helm values
         uses: mikefarah/yq@v4.43.1
         with:
-          cmd: yq '.buildkit.image.tag' deployments/helm/hephaestus/values.yaml
+          cmd: yq '.buildkit.rootlessImage.tag' deployments/helm/hephaestus/values.yaml
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -127,7 +127,7 @@ jobs:
         name: Extract image details from Helm values
         uses: mikefarah/yq@v4.43.1
         with:
-          cmd: yq '.buildkit.image.tag' deployments/helm/hephaestus/values.yaml | sed 's/-rootless//'
+          cmd: yq '.buildkit.image.tag' deployments/helm/hephaestus/values.yaml
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
The previous PR (#246) updated how the helm chart references the buildkit images, but our build process to vendor the buildkit images uses that chart's values, using the same string substitution separately, to determine the base image. This causes us to use the incorrect image when vendoring buildkit.