### PR TITLE
rootless updates

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -48,9 +48,12 @@ spec:
           securityContext:
             {{- if .Values.buildkit.rootless }}
             # NOTE: To change UID/GID, you need to rebuild the image
+            # see https://github.com/moby/buildkit/docs/rootless.md#change-uidgid
             runAsUser: {{ .Values.buildkit.rootlessUser }}
             runAsGroup: {{ .Values.buildkit.rootlessUser }}
             seccompProfile:
+              type: Unconfined
+            appArmorProfile:
               type: Unconfined
             {{- else }}
             allowPrivilegeEscalation: true
@@ -64,8 +67,14 @@ spec:
             {{- if .Values.buildkit.debug }}
             - --debug
             {{- end }}
+            {{- if .Values.buildkit.rootless }}
             {{- with .Values.buildkit.args }}
               {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- else }}
+            {{- with .Values.buildkit.args }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- end }}
           {{- with .Values.podEnv }}
           env:

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
       securityContext:
         runAsNonRoot: {{ .Values.buildkit.rootless }}
         runAsUser: {{ ternary .Values.buildkit.rootlessUser 0 .Values.buildkit.rootless }}
-        fsGroup: {{ ternary .Values.buildkit.rootlessUser 0 .Values.buildkit.rootless }}
+        fsGroup: {{ ternary .Values.buildkit.rootlessGroup 0 .Values.buildkit.rootless }}
         fsGroupChangePolicy: "OnRootMismatch"
         seLinuxOptions:
           type: spc_t
@@ -50,15 +50,15 @@ spec:
             # NOTE: To change UID/GID, you need to rebuild the image
             # see https://github.com/moby/buildkit/docs/rootless.md#change-uidgid
             runAsUser: {{ .Values.buildkit.rootlessUser }}
-            runAsGroup: {{ .Values.buildkit.rootlessUser }}
+            runAsGroup: {{ .Values.buildkit.rootlessGroup }}
             seccompProfile:
               type: Unconfined
             appArmorProfile:
               type: Unconfined
             {{- else }}
             allowPrivilegeEscalation: true
-            privileged: true
             {{- end }}
+            privileged: true
           image: {{ include "hephaestus.buildkit.image" . }}
           imagePullPolicy: {{ .Values.buildkit.image.pullPolicy }}
           args:
@@ -67,14 +67,8 @@ spec:
             {{- if .Values.buildkit.debug }}
             - --debug
             {{- end }}
-            {{- if .Values.buildkit.rootless }}
             {{- with .Values.buildkit.args }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- else }}
-            {{- with .Values.buildkit.args }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
             {{- end }}
           {{- with .Values.podEnv }}
           env:

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -256,7 +256,7 @@ buildkit:
 
   # UID for rootless user in rootless mode
   # NOTE: You MUST have a custom image if using anything other than 1000
-  rootlessUser: 1000
+  rootlessUser: 1001
 
   # Amount of storage GC keeps locally (bytes). This value should be less than the
   # total amount of available persistent storage (e.g. 75% of 20Gi)
@@ -273,7 +273,7 @@ buildkit:
   image:
     registry: ""
     repository: moby/buildkit
-    tag: v0.18.2
+    tag: v0.20.2
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -281,7 +281,7 @@ buildkit:
   rootlessImage:
     registry: ""
     repository: moby/buildkit
-    tag: v0.18.2-rootless
+    tag: v0.20.2-rootless
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -354,6 +354,7 @@ buildkit:
   priorityClassName: ""
 
   # Buildkit container extra args, i.e ["--oci-worker-snapshotter=fuse-overlayfs"]
+  # or --oci-worker-no-process-sandbox
   args: []
 
   # Affinities for buildkit pod assignment

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -254,9 +254,11 @@ buildkit:
   # Run buildkit in rootless mode
   rootless: true
 
-  # UID for rootless user in rootless mode
+  # UID/GID for rootless user in rootless mode
   # NOTE: You MUST have a custom image if using anything other than 1000
-  rootlessUser: 1001
+  # see https://github.com/moby/buildkit/docs/rootless.md#change-uidgid
+  rootlessUser: 100000
+  rootlessGroup: 65536
 
   # Amount of storage GC keeps locally (bytes). This value should be less than the
   # total amount of available persistent storage (e.g. 75% of 20Gi)


### PR DESCRIPTION
- Due to flag discrepancies between docker and containerd, per the [documented tip](https://github.com/moby/buildkit/blob/f8c19098c91a0cd4a2d9cd35e2b3c2a1c8b3f622/docs/rootless.md#change-uidgid) around `security-opt` flags, I've moved `--privileged` outside of the `rootless` eval
- Updated uid/gid for rootless