### PR TITLE
PLAT-9281: Make securityContext for buildkit container configurable

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -50,11 +50,9 @@ spec:
             # NOTE: To change UID/GID, you need to rebuild the image
             runAsUser: {{ .Values.buildkit.rootlessUser }}
             runAsGroup: {{ .Values.buildkit.rootlessUser }}
-            seccompProfile:
-              type: Unconfined
+            {{- toYaml .Values.buildkit.rootlessContainerSecurityContext | nindent 12}}
             {{- else }}
-            allowPrivilegeEscalation: true
-            privileged: true
+            {{- toYaml .Values.buildkit.containerSecurityContext | nindent 12}}
             {{- end }}
           image: {{ include "hephaestus.buildkit.image" . }}
           imagePullPolicy: {{ .Values.buildkit.image.pullPolicy }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -335,6 +335,16 @@ buildkit:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
+  # Non-rootless container's securityContext
+  containerSecurityContext:
+    allowPrivilegeEscalation: true
+    privileged: true
+
+  # Rootless container security context (sans user/group)
+  rootlessContainerSecurityContext:
+    seccompProfile:
+      type: Unconfined
+
   # Number of buildkit pods to run
   replicaCount: 0
 


### PR DESCRIPTION
The buildkit's container securityContext isn't configurable. Added variables for it for both the rootless and rootful (umm) modes.