### PR TITLE
Rootless configs

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 data:
   {{- with .Values.buildkit }}
+  {{- if .rootless }} # Guarantee rootless subuid/subgid mappings
+  subgid: |
+    user:100000:65536
+  subuid: |
+    user:100000:65536
+  {{- end -}}
   buildkitd.toml: |
     [grpc]
       address = [ "tcp://0.0.0.0:{{ .service.port }}", "{{ .rootless | ternary (printf "unix:///run/user/%v/buildkit/buildkitd.sock" .rootlessUser) "unix:///run/buildkit/buildkitd.sock" }}" ]

--- a/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/configmap.yaml
@@ -6,12 +6,6 @@ metadata:
     {{- include "hephaestus.buildkit.labels.standard" . | nindent 4 }}
 data:
   {{- with .Values.buildkit }}
-  {{- if .rootless }} # Guarantee rootless subuid/subgid mappings
-  subgid: |
-    user:100000:65536
-  subuid: |
-    user:100000:65536
-  {{- end -}}
   buildkitd.toml: |
     [grpc]
       address = [ "tcp://0.0.0.0:{{ .service.port }}", "{{ .rootless | ternary (printf "unix:///run/user/%v/buildkit/buildkitd.sock" .rootlessUser) "unix:///run/buildkit/buildkitd.sock" }}" ]
@@ -43,4 +37,10 @@ data:
       insecure = {{ . }}
       {{- end }}
     {{- end }}
+  {{- if .rootless }}
+  subgid: |
+    user:100000:65536
+  subuid: |
+    user:100000:65536
+  {{- end -}}
   {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -50,10 +50,9 @@ spec:
             # NOTE: To change UID/GID, you need to rebuild the image
             runAsUser: {{ .Values.buildkit.rootlessUser }}
             runAsGroup: {{ .Values.buildkit.rootlessUser }}
-            runAsNonRoot: true
-            {{- toYaml .Values.buildkit.rootlessContainerSecurityContext | nindent 12}}
+            {{- toYaml .Values.buildkit.rootlessContainerSecurityContext | nindent 12 }}
             {{- else }}
-            {{- toYaml .Values.buildkit.containerSecurityContext | nindent 12}}
+            {{- toYaml .Values.buildkit.containerSecurityContext | nindent 12 }}
             {{- end }}
           image: {{ include "hephaestus.buildkit.image" . }}
           imagePullPolicy: {{ .Values.buildkit.image.pullPolicy }}
@@ -62,7 +61,7 @@ spec:
             - /etc/buildkit/buildkitd.toml
             {{- if .Values.buildkit.rootless }}
             - --addr
-            - tcp://0.0.0.0:1234
+            - tcp://0.0.0.0:{{- default 1234 .Values.buildkit.service.port }}
             - --addr
             - unix:///run/user/{{ .Values.buildkit.rootlessUser }}/buildkit/buildkitd.sock
             {{- end -}}

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -60,6 +60,12 @@ spec:
           args:
             - --config
             - /etc/buildkit/buildkitd.toml
+            {{- if .Values.buildkit.rootless }}
+            - --addr
+            - tcp://0.0.0.0:1234
+            - --addr
+            - unix:///run/user/{{ .Values.buildkit.rootlessUser }}/buildkit/buildkitd.sock
+            {{- end -}}
             {{- if .Values.buildkit.debug }}
             - --debug
             {{- end }}

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -50,6 +50,7 @@ spec:
             # NOTE: To change UID/GID, you need to rebuild the image
             runAsUser: {{ .Values.buildkit.rootlessUser }}
             runAsGroup: {{ .Values.buildkit.rootlessUser }}
+            runAsNonRoot: true
             {{- toYaml .Values.buildkit.rootlessContainerSecurityContext | nindent 12}}
             {{- else }}
             {{- toYaml .Values.buildkit.containerSecurityContext | nindent 12}}
@@ -102,6 +103,14 @@ spec:
           resources:
             {{- toYaml .Values.buildkit.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.buildkit.rootless }}
+            - mountPath: /etc/subuid
+              name: config-vol
+              subPath: subuid
+            - mountPath: /etc/subgid
+              name: config-vol
+              subPath: subgid
+            {{- end }}
             - name: config-vol
               readOnly: true
               mountPath: /etc/buildkit/buildkitd.toml

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -342,6 +342,7 @@ buildkit:
 
   # Rootless container security context (sans user/group)
   rootlessContainerSecurityContext:
+    privileged: true
     seccompProfile:
       type: Unconfined
 

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -273,7 +273,7 @@ buildkit:
   image:
     registry: ""
     repository: moby/buildkit
-    tag: v0.18.2
+    tag: v0.20.2
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -281,7 +281,7 @@ buildkit:
   rootlessImage:
     registry: ""
     repository: moby/buildkit
-    tag: v0.18.2-rootless
+    tag: v0.20.2-rootless
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -342,6 +342,7 @@ buildkit:
 
   # Rootless container security context (sans user/group)
   rootlessContainerSecurityContext:
+    runAsNonRoot: true
     privileged: true
     seccompProfile:
       type: Unconfined


### PR DESCRIPTION
- Even when subgid/subuid fixes are baked into the dockerfile, when launched as a pod the istio settings propagate to `/etc/subgid` and `/etc/subuid`. With this configmap update, the right setting (`user:100000:65536`) gets all the way to the container.
- Due to flag discrepancies between docker and containerd, per the [documented tip](https://github.com/moby/buildkit/blob/f8c19098c91a0cd4a2d9cd35e2b3c2a1c8b3f622/docs/rootless.md#change-uidgid) around security-opt flags, we set `--privileged` in rootless too