### PR TITLE
Downgrade bitnami common version

### DIFF
--- a/deployments/helm/hephaestus/Chart.lock
+++ b/deployments/helm/hephaestus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.27.0
-digest: sha256:725ba9a398f9d90490c43eef0211c4404fef0ce30cfba1144f93eb5aacb572fb
-generated: "2025-01-03T01:30:49.986143162Z"
+  version: 2.19.1
+digest: sha256:4f539b1fbde383dd5bc020d77d70655108ed4c188b7329c1639df3f1e65de2e0
+generated: "2025-06-16T14:59:55.177595-07:00"

--- a/deployments/helm/hephaestus/Chart.yaml
+++ b/deployments/helm/hephaestus/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
     email: sonny.garcia@dominodatalab.com
 dependencies:
   - name: common
-    version: 2.27.0
+    version: 2.19.1
     repository: https://charts.bitnami.com/bitnami

--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,12 @@
 
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "packageRules": [
+      {
+          "description": "Disable helm dependency updates",
+          "matchManagers": ["helm"],
+          "enabled": false
+      }
   ]
 }


### PR DESCRIPTION
Our chart was actually built against this older version of the bitnami common chart. The reference was updated, but the code doesn't match it, doesn't work with it, and currently in production isn't using it. Downgrade the reference to the version we're actually using so that dep operations don't pull in a broken version.

The update was done by renovate, so I'm also disabling renovate managing helm dependencies. It's the only helm dependency in the repo.