### PR TITLE
PLAT-9527: Add ability to define a secret with google creds

### DIFF
--- a/deployments/helm/hephaestus/Chart.yaml
+++ b/deployments/helm/hephaestus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: hephaestus
-version: 0.0.0
-appVersion: "latest"
+version: 0.11.19
+appVersion: "0.11.19"
 kubeVersion: ">= 1.19.0-0"
 description: Kubernetes operator that builds OCI images using buildkit.
 home: https://github.com/dominodatalab/hephaestus

--- a/deployments/helm/hephaestus/Chart.yaml
+++ b/deployments/helm/hephaestus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: hephaestus
-version: 0.11.19
-appVersion: "0.11.19"
+version: 0.0.0
+appVersion: "latest"
 kubeVersion: ">= 1.19.0-0"
 description: Kubernetes operator that builds OCI images using buildkit.
 home: https://github.com/dominodatalab/hephaestus

--- a/deployments/helm/hephaestus/templates/controller/deployment.yaml
+++ b/deployments/helm/hephaestus/templates/controller/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - start
             - --config=/etc/hephaestus/config.yaml
           {{- with .Values.controller.manager }}
-          {{- if or .extraEnvVars .cloudRegistryAuth.azure.enabled $.Values.podEnv }}
+          {{- if or .extraEnvVars .cloudRegistryAuth.azure.enabled .cloudRegistryAuth.gcp.mountedCredentials.secretName $.Values.podEnv }}
           env:
             {{- with .extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
@@ -69,7 +69,7 @@ spec:
               value: {{ .clientSecret | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.secretName }}
+            {{- if .cloudRegistryAuth.gcp.mountedCredentials.secretName }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /google-creds/key.json
             {{- end }}
@@ -194,7 +194,7 @@ spec:
             defaultMode: 420
             secretName: {{ . | quote }}
             items:
-              - key: {{ .Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.keyName }}
+              - key: {{ $.Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.keyName | quote }}
                 path: key.json
         {{- end }}
         {{- with .Values.controller.extraVolumes }}

--- a/deployments/helm/hephaestus/templates/controller/deployment.yaml
+++ b/deployments/helm/hephaestus/templates/controller/deployment.yaml
@@ -69,6 +69,10 @@ spec:
               value: {{ .clientSecret | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.secretName }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /google-creds/key.json
+            {{- end }}
             {{- with $.Values.podEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -112,6 +116,12 @@ spec:
             {{- if .Values.controller.vector.enabled }}
             - name: log-vol
               mountPath: {{ include "hephaestus.logfileDir" . | quote }}
+            {{- end }}
+            {{- if .Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.secretName }}
+            - name: google-creds
+              mountPath: /google-creds/key.json
+              subPath: key.json
+              readOnly: true
             {{- end }}
             {{- with .Values.controller.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -177,6 +187,15 @@ spec:
         {{- if .Values.controller.vector.enabled }}
         - name: log-vol
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.secretName }}
+        - name: google-creds
+          secret:
+            defaultMode: 420
+            secretName: {{ . | quote }}
+            items:
+              - key: {{ .Values.controller.manager.cloudRegistryAuth.gcp.mountedCredentials.keyName }}
+                path: key.json
         {{- end }}
         {{- with .Values.controller.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -170,6 +170,10 @@ controller:
       gcp:
         enabled: false
         serviceAccount: ""
+        # For accessing from non-GKE installs
+        mountedCredentials:
+          secretName: ""
+          keyName: ""
 
     # Build status messaging configuration
     messaging:


### PR DESCRIPTION
We have a customer who wants to access their google artifact registry from their domino cloud control plane, but because of the way hephaestus works, it will want to do cloud authorization to gcp with these images.

This PR provides a mechanism to setup that authorization to gcr:

```
kubectl -n domino-compute create secret generic gcp-service-account --from-file=key.json=/path/to/service-account/creds.json

# Domino installer config:
[...]
release_overrides:
  chart_values:
     controller:
      manager:
        cloudRegistryAuth:
          gcp:
            mountedCredentials:
              secretName: gcp-service-account
              keyName: key.json
```

This will mount the google credentials into the hephaestus-manager pod, allowing it to auth for these images.