### PR TITLE
PLAT-9527: Don't use the registry token in gcr

### DIFF
--- a/.github/actions/push-multiple-container-images/action.yaml
+++ b/.github/actions/push-multiple-container-images/action.yaml
@@ -69,11 +69,11 @@ runs:
           name=${{ inputs.registry_quay }}/domino/${{ inputs.repository_quay }}
           name=${{ inputs.registry_gh }}/dominodatalab/hephaestus
         tags: |
-          type=ref,event=branch, suffix=${{ inputs.suffix }}
+          type=ref,event=branch,suffix=${{ inputs.suffix }}
           type=ref,event=pr,suffix=${{ inputs.suffix }}
           type=semver,pattern={{version}},suffix=${{ inputs.suffix }}
-          type=semver,pattern={{major}}.{{minor}}, suffix=${{ inputs.suffix }}
-          type=sha
+          type=semver,pattern={{major}}.{{minor}},suffix=${{ inputs.suffix }}
+          type=sha,suffix=${{ inputs.suffix }}
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:

--- a/.github/actions/push-multiple-container-images/action.yaml
+++ b/.github/actions/push-multiple-container-images/action.yaml
@@ -67,7 +67,7 @@ runs:
       with:
         images: |
           name=${{ inputs.registry_quay }}/domino/${{ inputs.repository_quay }}
-          name=${{ inputs.registry_gh }}/dominodatalab/hephaestus
+          # name=${{ inputs.registry_gh }}/dominodatalab/hephaestus
         tags: |
           type=ref,event=branch,suffix=${{ inputs.suffix }}
           type=ref,event=pr,suffix=${{ inputs.suffix }}

--- a/.github/actions/push-multiple-container-images/action.yaml
+++ b/.github/actions/push-multiple-container-images/action.yaml
@@ -67,7 +67,7 @@ runs:
       with:
         images: |
           name=${{ inputs.registry_quay }}/domino/${{ inputs.repository_quay }}
-          # name=${{ inputs.registry_gh }}/dominodatalab/hephaestus
+          name=${{ inputs.registry_gh }}/dominodatalab/hephaestus
         tags: |
           type=ref,event=branch,suffix=${{ inputs.suffix }}
           type=ref,event=pr,suffix=${{ inputs.suffix }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,60 @@ jobs:
           platforms: ${{ matrix.platforms }}
           suffix: ${{ matrix.suffix }}
           dockerfile: ${{ matrix.dockerfile }}
+  docker-arm:
+    runs-on: ubuntu-latest-arm
+    needs: build
+    outputs:
+      version: ${{ steps.docker_push.outputs.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile.debug # debug has to be first because Github Matrixes share same output and last wins
+            registry_gh: ghcr.io
+            username_gh: dominodatalab
+            password_gh: "blank"
+            repository_gh: ${{ github.repository }}
+            registry_quay: quay.io
+            username_quay: "blank"
+            password_quay: "blank"
+            repository_quay: "hephaestus"
+            suffix: "-debug"
+            platforms: linux/arm64
+          - dockerfile: ./Dockerfile
+            registry_gh: ghcr.io
+            username_gh: dominodatalab
+            password_gh: "blank"
+            repository_gh: ${{ github.repository }}
+            registry_quay: quay.io
+            username_quay: "blank"
+            password_quay: "blank"  # we have to resort to tricks like this because GitHub doesnt allow secrets in matrix sections
+            repository_quay: "hephaestus"
+            suffix: ""
+            platforms: linux/arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - id: docker_push
+        uses: ./.github/actions/push-multiple-container-images
+        with:
+          registry_gh: ${{ matrix.registry_gh }}
+          username_gh: ${{ matrix.username_gh }}
+          password_gh: ${{ secrets.GITHUB_TOKEN }}
+          repository_gh: ${{ matrix.repository_gh }}
+          registry_quay: ${{ matrix.registry_quay }}
+          username_quay: ${{ secrets.QUAY_USERNAME }}
+          password_quay: ${{ secrets.QUAY_PASSWORD }}
+          repository_quay: ${{ matrix.repository_quay }}
+          platforms: ${{ matrix.platforms }}
+          suffix: ${{ matrix.suffix }}
+          dockerfile: ${{ matrix.dockerfile }}
+
   helm:
     runs-on: ubuntu-latest
     needs: docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
           suffix: ${{ matrix.suffix }}
           dockerfile: ${{ matrix.dockerfile }}
   docker-arm:
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     needs: build
     outputs:
       version: ${{ steps.docker_push.outputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   pull_request: {}
 env:
   GO_VERSION: "1.24"
-  BUILD_PLATFORMS: linux/amd64,linux/arm64
+  BUILD_PLATFORMS: linux/amd64
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
             password_quay: "blank"
             repository_quay: "hephaestus"
             suffix: "-debug"
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - dockerfile: ./Dockerfile
             registry_gh: ghcr.io
             username_gh: dominodatalab
@@ -64,7 +64,7 @@ jobs:
             password_quay: "blank"  # we have to resort to tricks like this because GitHub doesnt allow secrets in matrix sections
             repository_quay: "hephaestus"
             suffix: ""
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
 
     steps:
       - name: Checkout code

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -94,5 +94,6 @@ func (g *gcrProvider) authenticate(
 	return &registry.AuthConfig{
 		Username:      "oauth2accesstoken",
 		Password:      token.AccessToken,
+		RegistryToken: "",
 	}, nil
 }

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -2,9 +2,12 @@ package gcr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -84,6 +87,72 @@ func (g *gcrProvider) authenticate(
 	token, err := g.tokenSource.Token()
 	if err != nil {
 		err = fmt.Errorf("unable to access GCR token from oauth: %w", err)
+		logger.Info(err.Error())
+
+		return nil, err
+	}
+
+	loginServerURL := "https://" + match[0]
+	directive, err := defaultChallengeLoginServer(ctx, loginServerURL)
+	if err != nil {
+		err = fmt.Errorf("GCR registry %q is unusable: %w", loginServerURL, err)
+		logger.Info(err.Error())
+
+		return nil, err
+	}
+
+	// obtain the registry token
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, directive.Realm, nil)
+	if err != nil {
+		err = fmt.Errorf("bad realm provided by GCR: %w", err)
+		logger.Info(err.Error())
+
+		return nil, err
+	}
+
+	v := url.Values{}
+	v.Set("service", directive.Service)
+	v.Set("client_id", "hephaestus")
+	req.URL.RawQuery = v.Encode()
+	req.URL.User = url.UserPassword("oauth2accesstoken", token.AccessToken)
+	resp, err := defaultClient.Do(req)
+	if err != nil {
+		err = fmt.Errorf("request to access GCR registry token failed with Error: %w", err)
+		logger.Info(err.Error())
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("unable to read response body %w", err)
+		logger.Info(err.Error())
+
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("failed to obtain token, received unexpected response code: %d\nresponse: %q",
+			resp.StatusCode, content)
+		logger.Info(err.Error())
+
+		return nil, err
+	}
+
+	var response tokenResponse
+	if err = json.Unmarshal(content, &response); err != nil {
+		err = fmt.Errorf("failed unmarshal json token response: %w", err)
+		return nil, err
+	}
+
+	// Some registries set access_token instead of token.
+	if response.AccessToken != "" {
+		response.Token = response.AccessToken
+	}
+
+	// Find a token to turn into a Bearer authenticator
+	if response.Token == "" {
+		err = fmt.Errorf("no GCR token in bearer response:\n%s", content)
 		logger.Info(err.Error())
 
 		return nil, err

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -162,7 +162,7 @@ func (g *gcrProvider) authenticate(
 	logger.Info(fmt.Sprintf("Successfully authenticated with GCR %q", server))
 	// buildkit only supports username/password
 	return &registry.AuthConfig{
-		Username:      "oauth2accesstoken",
-		Password:      token.AccessToken,
+		Username: "oauth2accesstoken",
+		Password: token.AccessToken,
 	}, nil
 }

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -163,6 +163,6 @@ func (g *gcrProvider) authenticate(
 	return &registry.AuthConfig{
 		Username:      "oauth2accesstoken",
 		Password:      token.AccessToken,
-		RegistryToken: response.Token,
+		RegistryToken: "",
 	}, nil
 }

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -2,12 +2,9 @@ package gcr
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -87,72 +84,6 @@ func (g *gcrProvider) authenticate(
 	token, err := g.tokenSource.Token()
 	if err != nil {
 		err = fmt.Errorf("unable to access GCR token from oauth: %w", err)
-		logger.Info(err.Error())
-
-		return nil, err
-	}
-
-	loginServerURL := "https://" + match[0]
-	directive, err := defaultChallengeLoginServer(ctx, loginServerURL)
-	if err != nil {
-		err = fmt.Errorf("GCR registry %q is unusable: %w", loginServerURL, err)
-		logger.Info(err.Error())
-
-		return nil, err
-	}
-
-	// obtain the registry token
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, directive.Realm, nil)
-	if err != nil {
-		err = fmt.Errorf("bad realm provided by GCR: %w", err)
-		logger.Info(err.Error())
-
-		return nil, err
-	}
-
-	v := url.Values{}
-	v.Set("service", directive.Service)
-	v.Set("client_id", "hephaestus")
-	req.URL.RawQuery = v.Encode()
-	req.URL.User = url.UserPassword("oauth2accesstoken", token.AccessToken)
-	resp, err := defaultClient.Do(req)
-	if err != nil {
-		err = fmt.Errorf("request to access GCR registry token failed with Error: %w", err)
-		logger.Info(err.Error())
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	content, err := io.ReadAll(resp.Body)
-	if err != nil {
-		err = fmt.Errorf("unable to read response body %w", err)
-		logger.Info(err.Error())
-
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("failed to obtain token, received unexpected response code: %d\nresponse: %q",
-			resp.StatusCode, content)
-		logger.Info(err.Error())
-
-		return nil, err
-	}
-
-	var response tokenResponse
-	if err = json.Unmarshal(content, &response); err != nil {
-		err = fmt.Errorf("failed unmarshal json token response: %w", err)
-		return nil, err
-	}
-
-	// Some registries set access_token instead of token.
-	if response.AccessToken != "" {
-		response.Token = response.AccessToken
-	}
-
-	// Find a token to turn into a Bearer authenticator
-	if response.Token == "" {
-		err = fmt.Errorf("no GCR token in bearer response:\n%s", content)
 		logger.Info(err.Error())
 
 		return nil, err

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -92,6 +92,7 @@ func (g *gcrProvider) authenticate(
 		return nil, err
 	}
 
+	// We have everything we need to login, but obtain bearer token as sanity check
 	loginServerURL := "https://" + match[0]
 	directive, err := defaultChallengeLoginServer(ctx, loginServerURL)
 	if err != nil {
@@ -163,6 +164,5 @@ func (g *gcrProvider) authenticate(
 	return &registry.AuthConfig{
 		Username:      "oauth2accesstoken",
 		Password:      token.AccessToken,
-		RegistryToken: "",
 	}, nil
 }

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr.go
@@ -94,6 +94,5 @@ func (g *gcrProvider) authenticate(
 	return &registry.AuthConfig{
 		Username:      "oauth2accesstoken",
 		Password:      token.AccessToken,
-		RegistryToken: "",
 	}, nil
 }

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
@@ -148,7 +148,6 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -165,7 +164,6 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -184,7 +182,6 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
@@ -28,10 +28,6 @@ var defaultTestingErr = errors.New("default error message")
 func TestAuthenticate(t *testing.T) {
 	defaultCtx := context.Background()
 
-	// Canceled context for testing failed do request
-	canceledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-
 	// logger for comparing expected vs actual logging.
 	observerCore, observedLogs := observer.New(zap.DebugLevel)
 	log := zapr.NewLogger(zap.New(observerCore))
@@ -43,16 +39,9 @@ func TestAuthenticate(t *testing.T) {
 
 	t.Cleanup(ts.Close)
 
-	// test server IP and port information for error logging
-	tsAddress := ts.Listener.Addr()
-
 	// expected errors
 	invalidUrlErr := errors.New(fmt.Sprintf("invalid GCR URL test-ts should match %s", gcrRegex))
 	gcrTokenAccessErr := errors.New("unable to access GCR token from oauth: default error message")
-	gcrRegistryErr := errors.New("GCR registry \"https://hi-docker.pkg.dev\" is unusable: default error message")
-	ctxCanceledErr := errors.New(fmt.Sprintf("request to access GCR registry token failed with Error: Get \"http://oauth2accesstoken:***@%s?client_id=hephaestus&service=serviceName\": context canceled", tsAddress.String()))
-	non200StatusErr := errors.New("failed to obtain token, received unexpected response code: 400\nresponse: \"nope\"")
-	noResTokenErr := errors.New("no GCR token in bearer response:\n{\"token\":\"\",\"access_token\":\"\",\"refresh_token\":\"\"}")
 
 	for _, tt := range []struct {
 		name               string
@@ -83,61 +72,6 @@ func TestAuthenticate(t *testing.T) {
 			loginChallenger:    defaultChallengeLoginServer,
 			expectedLogMessage: gcrTokenAccessErr.Error(),
 			expectedError:      gcrTokenAccessErr,
-		},
-		{
-			name:       "failed_challenge_ts_error",
-			serverName: "hi-docker.pkg.dev",
-			ctx:        defaultCtx,
-			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
-				"serviceName",
-				"realmName",
-				defaultTestingErr,
-			),
-			expectedLogMessage: gcrRegistryErr.Error(),
-			expectedError:      gcrRegistryErr,
-		},
-		{
-			name:       "failed_do_request",
-			serverName: "gcr.io",
-			ctx:        canceledCtx,
-			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
-				"serviceName",
-				ts.URL,
-				nil,
-			),
-			expectedLogMessage: ctxCanceledErr.Error(),
-			expectedError:      ctxCanceledErr,
-		},
-		{
-			name:       "non_200_response_code",
-			serverName: "gcr.io",
-			ctx:        defaultCtx,
-			roundTripper: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusBadRequest,
-					Body:       io.NopCloser(strings.NewReader(`nope`)),
-				}, nil
-			}),
-			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
-				"serviceName",
-				ts.URL,
-				nil,
-			),
-			expectedLogMessage: non200StatusErr.Error(),
-			expectedError:      non200StatusErr,
-		},
-		{
-			name:       "failed_no_token_in_response",
-			serverName: "gcr.io",
-			ctx:        defaultCtx,
-			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
-				"serviceName",
-				ts.URL,
-				nil,
-			),
-			roundTripper:       createRoundTripperFunc(t, tokenResponse{}, http.StatusOK),
-			expectedLogMessage: noResTokenErr.Error(),
-			expectedError:      noResTokenErr,
 		},
 		// success
 		{

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
@@ -82,7 +82,6 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -99,7 +98,6 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -118,7 +116,6 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
@@ -82,6 +82,7 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
+				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -98,6 +99,7 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
+				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -116,6 +118,7 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
+				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr_test.go
@@ -148,7 +148,7 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "test-access-token",
+				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -165,7 +165,7 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "regular-token",
+				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",
@@ -184,7 +184,7 @@ func TestAuthenticate(t *testing.T) {
 			authConfig: &registry.AuthConfig{
 				Username:      "oauth2accesstoken",
 				Password:      "hey",
-				RegistryToken: "regular-token",
+				RegistryToken: "",
 			},
 			loginChallenger: cloudauthtest.FakeChallengeLoginServer(
 				"serviceName",


### PR DESCRIPTION
Problem:

* Accessing at least one particular customer's `us.gcr.io` endpoint via injected service account credentials on a non-GKE cluster authenticates initially, but fails at pull time with a 401
* Building arm is slow as hell
* sha tag for debug was overwriting the non-debug one (or vice versa, it's a race)

Changes:
* Remove `registrytoken` from gcp auth method
  * Our GCR/GAR support gets a bearer token and supplies it in the registrytoken field
  * It seems that with this account in particular, the bearer token we have does not function
    * It does work with our own AR 
  * I suspect it's not scoped to the image registry or paths we're working with
  * However, I don't think there's any point in propagating this. Buildkit can handle it just fine with the oauth token.
* Run a separate arm build process that happens in parallel, on an actual arm gha runner
* Add the debug suffix to the sha too