### PR TITLE
PLAT-9268 - Switch to socket probe

### DIFF
--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -80,11 +80,9 @@ spec:
               protocol: TCP
               containerPort: {{ .Values.buildkit.service.port }}
           livenessProbe:
-            exec:
-              command:
-                - buildctl
-                - debug
-                - workers
+            exec: null
+            tcpSocket:
+              port: 1234
             {{- with .Values.buildkit.livenessProbe }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
@@ -93,11 +91,9 @@ spec:
             successThreshold: {{ .successThreshold }}
             {{- end }}
           readinessProbe:
-            exec:
-              command:
-                - buildctl
-                - debug
-                - workers
+            exec: null
+            tcpSocket:
+              port: 1234
             {{- with .Values.buildkit.readinessProbe }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}

--- a/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
+++ b/deployments/helm/hephaestus/templates/buildkit/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           livenessProbe:
             exec: null
             tcpSocket:
-              port: 1234
+              port: {{- default 1234 .Values.buildkit.service.port }}
             {{- with .Values.buildkit.livenessProbe }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
@@ -93,7 +93,7 @@ spec:
           readinessProbe:
             exec: null
             tcpSocket:
-              port: 1234
+              port: {{- default 1234 .Values.buildkit.service.port }}
             {{- with .Values.buildkit.readinessProbe }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -300,19 +300,19 @@ buildkit:
 
   # Buildkitd liveness probe
   livenessProbe:
+    failureThreshold: 3
     initialDelaySeconds: 5
     periodSeconds: 30
-    timeoutSeconds: 10
-    failureThreshold: 3
     successThreshold: 1
+    timeoutSeconds: 30
 
   # Buildkitd readiness probe
   readinessProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 30
-    timeoutSeconds: 10
     failureThreshold: 3
+    initialDelaySeconds: 5
+    periodSeconds: 10
     successThreshold: 1
+    timeoutSeconds: 5
 
   # Resource requests and limits
   resources:


### PR DESCRIPTION
Problem:
`hephaestus-buildkit` pods are experiencing cgroup-related probe failures that prevent them from becoming ready, despite the containers starting successfully. 

The liveness and readiness probes are failing with the error:
`rpc error: code = Unknown desc = command error: error opening file '/sys/fs/cgroup/kubepods.slice/kubepods-pod[UUID].slice/crio-[CONTAINER_ID].scope/cgroup.freeze: No such file or directory`

Running `buildctl debug workers` works inside buildkit containers, but is problematic as a probe. Testing the TCP socket is more reliable and not susceptible to cgroup v1/v2 differences as well as others with CRI-O, etc.

Changes:
- Set the `exec.command` to `null`
- Set `tcpSocket.port: 1234` (also set in the buildkit args)
- Adjusted test thresholds
