### PR TITLE
Batch dependency updates (Maven, Kubernetes, Swagger, fsutil)

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -14,3 +14,6 @@ API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/ap
 API rule violation: list_type_missing,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageCacheStatus,Conditions
 API rule violation: names_match,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,DisableCacheLayerExport
 API rule violation: names_match,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildSpec,DisableLocalBuildCache
+API rule violation: streaming_list_type_json_tags,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildList,ListMeta
+API rule violation: streaming_list_type_json_tags,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageBuildMessageList,ListMeta
+API rule violation: streaming_list_type_json_tags,github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1,ImageCacheList,ListMeta

--- a/deployments/crds/hephaestus.dominodatalab.com_imagebuildmessages.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagebuildmessages.yaml
@@ -118,9 +118,7 @@ spec:
                 type: array
             type: object
         required:
-        - metadata
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/deployments/crds/hephaestus.dominodatalab.com_imagebuildmessages.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagebuildmessages.yaml
@@ -117,6 +117,10 @@ spec:
                   type: object
                 type: array
             type: object
+        required:
+        - metadata
+        - spec
+        - status
         type: object
     served: true
     storage: true

--- a/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
@@ -249,11 +249,16 @@ spec:
                         lifecycle.
                       type: string
                   required:
+                  - occurredAt
                   - phase
                   - previousPhase
                   type: object
                 type: array
             type: object
+        required:
+        - metadata
+        - spec
+        - status
         type: object
     served: true
     storage: true

--- a/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagebuilds.yaml
@@ -249,16 +249,13 @@ spec:
                         lifecycle.
                       type: string
                   required:
-                  - occurredAt
                   - phase
                   - previousPhase
                   type: object
                 type: array
             type: object
         required:
-        - metadata
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/deployments/crds/hephaestus.dominodatalab.com_imagecaches.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagecaches.yaml
@@ -166,6 +166,10 @@ spec:
                 description: Phase represents a step in a resource processing lifecycle.
                 type: string
             type: object
+        required:
+        - metadata
+        - spec
+        - status
         type: object
     served: true
     storage: true

--- a/deployments/crds/hephaestus.dominodatalab.com_imagecaches.yaml
+++ b/deployments/crds/hephaestus.dominodatalab.com_imagecaches.yaml
@@ -167,9 +167,7 @@ spec:
                 type: string
             type: object
         required:
-        - metadata
         - spec
-        - status
         type: object
     served: true
     storage: true

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/newrelic/go-agent/v3/integrations/nrzap v1.0.1
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
-	github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f
+	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f h1:MoxeMfHAe5Qj/ySSBfL8A7l1V+hxuluj8owsIEEZipI=
-github.com/tonistiigi/fsutil v0.0.0-20250605211040-586307ad452f/go.mod h1:BKdcez7BiVtBvIcef90ZPc6ebqIWr4JWD7+EvLm6J98=
+github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f h1:Z4NEQ86qFl1mHuCu9gwcE+EYCwDKfXAYXZbdIXyxmEA=
+github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f/go.mod h1:BKdcez7BiVtBvIcef90ZPc6ebqIWr4JWD7+EvLm6J98=
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 h1:2f304B10LaZdB8kkVEaoXvAMVan2tl9AiK4G0odjQtE=
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0/go.mod h1:278M4p8WsNh3n4a1eqiFcV2FGk7wE5fwUpUom9mK9lE=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -41,7 +41,8 @@ type ImageBuildSpec struct {
 type ImageBuildTransition struct {
 	PreviousPhase Phase       `json:"previousPhase"`
 	Phase         Phase       `json:"phase"`
-	OccurredAt    metav1.Time `json:"occurredAt,omitzero"`
+	// +optional
+	OccurredAt metav1.Time `json:"occurredAt,omitzero"`
 }
 
 type ImageBuildStatus struct {
@@ -77,10 +78,12 @@ type ImageBuildStatus struct {
 // +kubebuilder:printcolumn:name="Builder Address",type=string,JSONPath=".status.builderAddr",priority=10
 
 type ImageBuild struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageBuildSpec   `json:"spec,omitzero"`
+	Spec ImageBuildSpec `json:"spec,omitzero"`
+	// +optional
 	Status ImageBuildStatus `json:"status,omitzero"`
 }
 

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -41,7 +41,7 @@ type ImageBuildSpec struct {
 type ImageBuildTransition struct {
 	PreviousPhase Phase       `json:"previousPhase"`
 	Phase         Phase       `json:"phase"`
-	OccurredAt    metav1.Time `json:"occurredAt,omitempty"`
+	OccurredAt    metav1.Time `json:"occurredAt,omitzero"`
 }
 
 type ImageBuildStatus struct {
@@ -78,10 +78,10 @@ type ImageBuildStatus struct {
 
 type ImageBuild struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageBuildSpec   `json:"spec,omitempty"`
-	Status ImageBuildStatus `json:"status,omitempty"`
+	Spec   ImageBuildSpec   `json:"spec,omitzero"`
+	Status ImageBuildStatus `json:"status,omitzero"`
 }
 
 func (in *ImageBuild) ObjectKey() client.ObjectKey {
@@ -112,7 +112,7 @@ func (in *ImageBuild) SetPhase(p Phase) {
 
 type ImageBuildList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ImageBuild `json:"items"`
 }

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -39,8 +39,8 @@ type ImageBuildSpec struct {
 }
 
 type ImageBuildTransition struct {
-	PreviousPhase Phase       `json:"previousPhase"`
-	Phase         Phase       `json:"phase"`
+	PreviousPhase Phase `json:"previousPhase"`
+	Phase         Phase `json:"phase"`
 	// +optional
 	OccurredAt metav1.Time `json:"occurredAt,omitzero"`
 }

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -82,6 +82,7 @@ type ImageBuild struct {
 	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	Spec   ImageBuildSpec   `json:"spec,omitzero"`
+	// +optional
 	Status ImageBuildStatus `json:"status,omitzero"`
 }
 

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -78,11 +78,11 @@ type ImageBuildStatus struct {
 // +kubebuilder:printcolumn:name="Builder Address",type=string,JSONPath=".status.builderAddr",priority=10
 
 type ImageBuild struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageBuildSpec   `json:"spec,omitzero"`
+	Spec ImageBuildSpec `json:"spec,omitzero"`
 	// +optional
 	Status ImageBuildStatus `json:"status,omitzero"`
 }

--- a/pkg/api/hephaestus/v1/imagebuild_types.go
+++ b/pkg/api/hephaestus/v1/imagebuild_types.go
@@ -78,6 +78,7 @@ type ImageBuildStatus struct {
 
 type ImageBuild struct {
 	metav1.TypeMeta   `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	Spec   ImageBuildSpec   `json:"spec,omitzero"`

--- a/pkg/api/hephaestus/v1/imagebuildmessage_types.go
+++ b/pkg/api/hephaestus/v1/imagebuildmessage_types.go
@@ -27,17 +27,17 @@ type ImageBuildMessageStatus struct {
 
 type ImageBuildMessage struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageBuildMessageSpec   `json:"spec,omitempty"`
-	Status ImageBuildMessageStatus `json:"status,omitempty"`
+	Spec   ImageBuildMessageSpec   `json:"spec,omitzero"`
+	Status ImageBuildMessageStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
 
 type ImageBuildMessageList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ImageBuildMessage `json:"items"`
 }

--- a/pkg/api/hephaestus/v1/imagecache_types.go
+++ b/pkg/api/hephaestus/v1/imagecache_types.go
@@ -28,10 +28,10 @@ type ImageCacheStatus struct {
 
 type ImageCache struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageCacheSpec   `json:"spec,omitempty"`
-	Status ImageCacheStatus `json:"status,omitempty"`
+	Spec   ImageCacheSpec   `json:"spec,omitzero"`
+	Status ImageCacheStatus `json:"status,omitzero"`
 }
 
 func (in *ImageCache) GetConditions() *[]metav1.Condition {
@@ -50,7 +50,7 @@ func (in *ImageCache) SetPhase(p Phase) {
 
 type ImageCacheList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 
 	Items []ImageCache `json:"items"`
 }

--- a/pkg/api/hephaestus/v1/zz_generated.openapi.go
+++ b/pkg/api/hephaestus/v1/zz_generated.openapi.go
@@ -99,6 +99,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuild(ref common.ReferenceCallback) commo
 						},
 					},
 				},
+				Required: []string{"metadata", "spec", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -170,7 +171,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuildList(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"items"},
+				Required: []string{"metadata", "items"},
 			},
 		},
 		Dependencies: []string{
@@ -217,6 +218,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuildMessage(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"metadata", "spec", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -298,7 +300,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuildMessageList(ref common.ReferenceCall
 						},
 					},
 				},
-				Required: []string{"items"},
+				Required: []string{"metadata", "items"},
 			},
 		},
 		Dependencies: []string{
@@ -724,7 +726,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuildTransition(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"previousPhase", "phase"},
+				Required: []string{"previousPhase", "phase", "occurredAt"},
 			},
 		},
 		Dependencies: []string{
@@ -771,6 +773,7 @@ func schema_pkg_api_hephaestus_v1_ImageCache(ref common.ReferenceCallback) commo
 						},
 					},
 				},
+				Required: []string{"metadata", "spec", "status"},
 			},
 		},
 		Dependencies: []string{
@@ -818,7 +821,7 @@ func schema_pkg_api_hephaestus_v1_ImageCacheList(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"items"},
+				Required: []string{"metadata", "items"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/api/hephaestus/v1/zz_generated.openapi.go
+++ b/pkg/api/hephaestus/v1/zz_generated.openapi.go
@@ -99,7 +99,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuild(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"metadata", "spec", "status"},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -726,7 +726,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuildTransition(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"previousPhase", "phase", "occurredAt"},
+				Required: []string{"previousPhase", "phase"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"path"
@@ -227,9 +228,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) (string, error) {
 	}
 
 	// merge in preloaded data
-	for name, contents := range opts.SecretsData {
-		secrets[name] = contents
-	}
+	maps.Copy(secrets, opts.SecretsData)
 
 	contentsFS, err := fsutil.NewFS(contentsDir)
 	if err != nil {
@@ -285,9 +284,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) (string, error) {
 			return "", fmt.Errorf("cannot parse build args: %w", err)
 		}
 
-		for k, v := range attrs {
-			solveOpt.FrontendAttrs[k] = v
-		}
+		maps.Copy(solveOpt.FrontendAttrs, attrs)
 	}
 	for _, name := range opts.Images {
 		bkclientattrs := validateCompression(hephconfig.CompressionMethod, name)
@@ -304,7 +301,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) (string, error) {
 func (c *Client) Cache(ctx context.Context, image string) error {
 	return c.solveWith(ctx, func(buildDir string, solveOpt *bkclient.SolveOpt) error {
 		dockerfile := filepath.Join(buildDir, "Dockerfile")
-		contents := []byte(fmt.Sprintf("FROM %s\nRUN echo extract\n", image))
+		contents := fmt.Appendf(nil, "FROM %s\nRUN echo extract\n", image)
 		if err := os.WriteFile(dockerfile, contents, 0644); err != nil {
 			return fmt.Errorf("failed to create dockerfile: %w", err)
 		}

--- a/pkg/controller/imagebuildmessage/component/amqpmessenger.go
+++ b/pkg/controller/imagebuildmessage/component/amqpmessenger.go
@@ -3,6 +3,7 @@ package component
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"path"
 	"strings"
@@ -60,7 +61,7 @@ func (c *AMQPMessengerComponent) Initialize(_ *core.Context, bldr *ctrl.Builder)
 	return nil
 }
 
-//nolint:maintidx,funlen
+//nolint:maintidx
 func (c *AMQPMessengerComponent) Reconcile(ctx *core.Context) (ctrl.Result, error) {
 	log := ctx.Log
 	obj := ctx.Object
@@ -209,9 +210,7 @@ func (c *AMQPMessengerComponent) Reconcile(ctx *core.Context) (ctrl.Result, erro
 				message.Annotations = map[string]string{}
 			}
 			message.Annotations[compressedImageSizeBytesAnnotation] = ib.Status.CompressedImageSizeBytes
-			for key, value := range ib.Status.Labels {
-				message.Annotations[key] = value
-			}
+			maps.Copy(message.Annotations, ib.Status.Labels)
 		case hephv1.PhaseFailed:
 			if ib.Status.Conditions == nil {
 				return ctrl.Result{Requeue: true}, nil

--- a/pkg/controller/support/credentials/cloudauth/acr/acr_integration_test.go
+++ b/pkg/controller/support/credentials/cloudauth/acr/acr_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package acr
 

--- a/pkg/controller/support/credentials/cloudauth/challenge.go
+++ b/pkg/controller/support/credentials/cloudauth/challenge.go
@@ -48,8 +48,7 @@ func ChallengeLoginServer(ctx context.Context, loginServerURL string) (*AuthDire
 	}
 
 	authParams := map[string]string{}
-	params := strings.Split(authSections[1], ",")
-	for _, p := range params {
+	for p := range strings.SplitSeq(authSections[1], ",") {
 		parts := strings.SplitN(strings.TrimSpace(p), "=", authValueIndex)
 		authParams[parts[0]] = strings.Trim(parts[1], `"`)
 	}

--- a/pkg/controller/support/credentials/cloudauth/challenge.go
+++ b/pkg/controller/support/credentials/cloudauth/challenge.go
@@ -48,7 +48,7 @@ func ChallengeLoginServer(ctx context.Context, loginServerURL string) (*AuthDire
 	}
 
 	authParams := map[string]string{}
-	for p := range strings.SplitSeq(authSections[1], ",") {
+	for _, p := range strings.Split(authSections[1], ",") {
 		parts := strings.SplitN(strings.TrimSpace(p), "=", authValueIndex)
 		authParams[parts[0]] = strings.Trim(parts[1], `"`)
 	}

--- a/pkg/controller/support/credentials/cloudauth/challenge.go
+++ b/pkg/controller/support/credentials/cloudauth/challenge.go
@@ -48,7 +48,7 @@ func ChallengeLoginServer(ctx context.Context, loginServerURL string) (*AuthDire
 	}
 
 	authParams := map[string]string{}
-	for _, p := range strings.Split(authSections[1], ",") {
+	for _, p := range strings.Split(authSections[1], ",") { //nolint:modernize
 		parts := strings.SplitN(strings.TrimSpace(p), "=", authValueIndex)
 		authParams[parts[0]] = strings.Trim(parts[1], `"`)
 	}

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -30,7 +30,7 @@ type awsLogger struct {
 	logr.Logger
 }
 
-func (l awsLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
+func (l awsLogger) Logf(classification logging.Classification, format string, v ...any) {
 	var level int
 	if classification == logging.Debug {
 		level = 1

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr_integration_test.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package ecr
 

--- a/pkg/controller/support/credentials/cloudauth/gcr/gcr_integration_test.go
+++ b/pkg/controller/support/credentials/cloudauth/gcr/gcr_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package gcr
 

--- a/scripts/sdk/generate.sh
+++ b/scripts/sdk/generate.sh
@@ -78,8 +78,7 @@ go run "$SCRIPT_DIR"/main.go -json $KUBERNETES_SWAGGER_FILE -version "$VERSION" 
 
 info "Generating Java client library"
 mkdir -p "$GEN_DIR"
-##--invoker-package io.kubernetes.client.openapi 
-##	--invoker-package com.dominodatalab.hephaestus.v1.client \
+
 docker run -q --user "$(id -u):$(id -g)" --rm -v "$PROJECT_DIR:/wd" --workdir /wd \
 	openapitools/openapi-generator-cli:$OPENAPI_GENERATOR_CLI_VERSION generate \
 	--input-spec /wd/$SWAGGER_FILE \
@@ -88,7 +87,7 @@ docker run -q --user "$(id -u):$(id -g)" --rm -v "$PROJECT_DIR:/wd" --workdir /w
 	--library okhttp-gson \
 	--api-package com.dominodatalab.hephaestus.v1.apis \
 	--model-package com.dominodatalab.hephaestus.v1.models \
-    --invoker-package io.kubernetes.client.openapi \
+    --invoker-package com.dominodatalab.hephaestus.v1.client \
 	--group-id com.dominodatalab.hephaestus \
 	--artifact-id hephaestus-client-java \
 	--additional-properties dateLibrary=java8,testFramework=junit5  \
@@ -104,7 +103,7 @@ docker run -q --user "$(id -u):$(id -g)" --rm -v "$PROJECT_DIR:/wd" --workdir /w
 	--generate-alias-as-model
 
 info "Copying generated Java files to $JAVA_DIR"
-rm -rf "$GEN_DIR"/src/main/{java/io,AndroidManifest.xml}
+rm -rf "$GEN_DIR"/src/main/AndroidManifest.xml
 cp -r "$GEN_DIR"/docs "$JAVA_DIR"
 cp -r "$GEN_DIR"/src "$JAVA_DIR"
 rm -rf "$GEN_DIR"

--- a/scripts/sdk/pom.xml
+++ b/scripts/sdk/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.3</version>
+                <version>3.1.4</version>
             </plugin>
         </plugins>
     </build>

--- a/scripts/sdk/pom.xml
+++ b/scripts/sdk/pom.xml
@@ -11,7 +11,7 @@
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <swagger-core-version>1.6.15</swagger-core-version>
+        <swagger-core-version>1.6.16</swagger-core-version>
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.12.1</gson-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>

--- a/scripts/sdk/pom.xml
+++ b/scripts/sdk/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>24.0.0</version>
+            <version>24.0.0-legacy</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>


### PR DESCRIPTION
## Summary

  Consolidates multiple Renovate dependency update PRs into a single release batch.

  ## Dependency Updates

  | Package | Language | Change |
  |---------|----------|--------|
  | `org.apache.maven.plugins:maven-deploy-plugin` | Java | `3.1.3` → `3.1.4` |
  | `io.kubernetes:client-java` | Java | `24.0.0` → `24.0.0-legacy` |
  | `io.swagger:swagger-annotations` | Java | `1.6.15` → `1.6.16` |
  | `github.com/tonistiigi/fsutil` | Go | `586307a` → `a2aa163` |

  ## Original PRs

  - #310 - maven-deploy-plugin update
  - #348 - kubernetes client-java update
  - #349 - swagger-annotations update
  - #370 - fsutil digest update

  ## Notes

  - All updates are minor/patch versions with no breaking changes expected
  - The kubernetes client-java update moves to the `-legacy` variant for compatibility