### PR TITLE
PLAT-9845 Add jobNodeSelector to CRD hook jobs

### DIFF
--- a/deployments/helm/hephaestus/templates/crd-hooks.yaml
+++ b/deployments/helm/hephaestus/templates/crd-hooks.yaml
@@ -99,7 +99,7 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.controller.nodeSelector }}
+      {{- with (.Values.controller.jobNodeSelector | default .Values.controller.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -156,7 +156,7 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.controller.nodeSelector }}
+      {{- with (.Values.controller.jobNodeSelector | default .Values.controller.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -112,6 +112,8 @@ controller:
 
   # Node labels for controller pod assignment
   nodeSelector: {}
+  # Node selector for Job pods. Defaults to nodeSelector if not set.
+  jobNodeSelector: {}
 
   # Controller pods priorityClassName
   priorityClassName: ""


### PR DESCRIPTION
Add jobNodeSelector to the crd-apply and crd-delete hook Jobs so they can target the domino-platform-jobs nodepool, falling back to controller.nodeSelector if unset.