### PR TITLE
PLAT-9883 - Improve Hephaestus CRD Hook Reliability

### DIFF
--- a/deployments/helm/hephaestus/templates/crd-hooks.yaml
+++ b/deployments/helm/hephaestus/templates/crd-hooks.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 rules:
   - apiGroups:
       - apiextensions.k8s.io
@@ -45,7 +45,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -66,8 +66,9 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
+  backoffLimit: 3
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -123,8 +124,9 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-delete
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
 spec:
+  backoffLimit: 3
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/deployments/helm/hephaestus/templates/crd-hooks.yaml
+++ b/deployments/helm/hephaestus/templates/crd-hooks.yaml
@@ -66,9 +66,10 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -124,9 +125,10 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-delete
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -171,3 +173,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+


### PR DESCRIPTION
On fresh installs, if the `hephaestus-crd-apply` hook Job fails due to a transient issue (e.g., `cert-manager` race or image pull delays), the Helm release enters a `failed` state before CRDs are created. This leads to a cascading failure:
- The **manager crash-loops permanently** because it cannot locate the missing CRDs.
- **Subsequent `helm upgrade` attempts fail** because the stale, failed hook resources (ServiceAccounts, Roles, etc.) are still present in the cluster, blocking Helm from re-creating them.

**Observed behavior:** On on-prem cluster deployments, `cert-manager` issuers were not ready when the hook ran. By the time certificates were issued (~6s later), the hook had already failed, leaving the release in an unrecoverable state without manual intervention.

## Root Cause

1.  **Missing `hook-failed` Delete Policy**: Failed hooks leave stale resources behind, which prevent Helm from successfully executing future upgrades or retries.
2.  **Lack of `backoffLimit`**: Relying on default Job behavior can exhaust retries before transient infrastructure conditions (like cert-manager reconciliation) have time to resolve.

## Justification: Why This Is Critical

- **Automation Deadlock**: Continuing as we were is not a viable option because it breaks the "self-healing" expectation of Kubernetes. Once a transient failure occurs, the deployment enters a deadlock that blocks automated CI/CD tools from recovering the release.
- **Improved Bootstrapping Reliability**: Fresh cluster installs are the most vulnerable time for race conditions. This change transforms a "hard fail" into a resilient, self-recovering process by allowing transient delays to resolve during the Job's backoff period.
- **Elimination of Manual Intervention**: Without these changes, every transient networking or scheduling delay requires a Platform Engineer to manually run `kubectl delete` and `helm upgrade` to unstick the cluster.

## Changes

Affected File: `deployments/helm/hephaestus/templates/crd-hooks.yaml`

1.  **Add `hook-failed` to `helm.sh/hook-delete-policy`**: Applied to hook resources `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding`. This ensures Helm cleans up failed attempts automatically.
2.  **Add `backoffLimit: 3`**: Added to both Job specifications to provide a total of 4 attempts (1 initial + 3 retries), which provides enough headroom for transient dependencies to stabilize.
3. **Add `ttlSecondsAfterFinished`**: Added to `crd-apply` and `crd-delete` jobs to allow for job completion. (Note: no `hook-failed` for these)

Behavior with the change:

- On failure: RBAC resources cleaned up immediately; Job + Pods remain for 1 hour (debug window)
- On retry: before-hook-creation deletes stale Job before creating new one
- On success: hook-succeeded cleans up everything immediately
- If forgotten: Kubernetes TTL controller garbage-collects after 1 hour

## Manual Remediation for Stuck Clusters

To manually recover clusters currently stuck in a failed state:

```bash
# Manually apply the CRDs to resolve the manager crash-loop
kubectl apply -f deployments/crds/ -n domino-compute

# Sync the Helm release to clear the failed state
helm upgrade hephaestus deployments/helm/hephaestus -n domino-compute
```