### PR TITLE
Add missing "+optional" markers to ObjectMeta and Status fields

### DIFF
--- a/pkg/api/hephaestus/v1/imagebuildmessage_types.go
+++ b/pkg/api/hephaestus/v1/imagebuildmessage_types.go
@@ -26,10 +26,12 @@ type ImageBuildMessageStatus struct {
 // +kubebuilder:subresource:status
 
 type ImageBuildMessage struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageBuildMessageSpec   `json:"spec,omitzero"`
+	Spec ImageBuildMessageSpec `json:"spec,omitzero"`
+	// +optional
 	Status ImageBuildMessageStatus `json:"status,omitzero"`
 }
 

--- a/pkg/api/hephaestus/v1/imagecache_types.go
+++ b/pkg/api/hephaestus/v1/imagecache_types.go
@@ -27,10 +27,12 @@ type ImageCacheStatus struct {
 // +kubebuilder:printcolumn:name="Target Pods",type=string,JSONPath=".status.buildkitPods",priority=10
 
 type ImageCache struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitzero"`
 
-	Spec   ImageCacheSpec   `json:"spec,omitzero"`
+	Spec ImageCacheSpec `json:"spec,omitzero"`
+	// +optional
 	Status ImageCacheStatus `json:"status,omitzero"`
 }
 

--- a/pkg/api/hephaestus/v1/zz_generated.openapi.go
+++ b/pkg/api/hephaestus/v1/zz_generated.openapi.go
@@ -218,7 +218,7 @@ func schema_pkg_api_hephaestus_v1_ImageBuildMessage(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"metadata", "spec", "status"},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -773,7 +773,7 @@ func schema_pkg_api_hephaestus_v1_ImageCache(ref common.ReferenceCallback) commo
 						},
 					},
 				},
-				Required: []string{"metadata", "spec", "status"},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
PR #374 properly removed the required `metadata` and `status` fields from the ImageBuildMessage and ImageCache types, but without the `// +optional` markers `make crds`/`controller-gen` treats fields inserted them back in.

Example build failure: https://github.com/dominodatalab/hephaestus/actions/runs/24464749312/job/71505663709