### PR TITLE
Fix ImageBuild stuck in Running when buildkit leaves progress channel…

### DIFF
--- a/deployments/helm/hephaestus/templates/controller/secret.yaml
+++ b/deployments/helm/hephaestus/templates/controller/secret.yaml
@@ -40,6 +40,9 @@ stringData:
       {{- with .Values.controller.manager.fetchAndExtractTimeout }}
       fetchAndExtractTimeout {{ . | quote }}
       {{- end }}
+      {{- with .Values.controller.manager.buildTimeout }}
+      buildTimeout: {{ . | quote }}
+      {{- end }}
       {{- with .Values.controller.manager.secrets }}
       secrets:
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/hephaestus/values.yaml
+++ b/deployments/helm/hephaestus/values.yaml
@@ -172,6 +172,11 @@ controller:
     # Defaults to 4.25 mins for fetch retries and an unlimited amount of time to extract.
     fetchAndExtractTimeout: null
 
+    # Maximum duration for a single buildkit Solve call. Guards against hung gRPC streams
+    # that would otherwise leave the ImageBuild stuck in Running and hold the buildkit
+    # worker lease. Null or zero disables the timeout.
+    buildTimeout: null
+
     # Global secrets (name: path) to expose into all image builds
     secrets: {}
 

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/cli/cli/config"
@@ -413,39 +414,56 @@ func (c *Client) solveWith(ctx context.Context, modify func(buildDir string, sol
 	return err
 }
 
+// runProgressSolve runs a solve producer and a progress consumer concurrently, guaranteeing the
+// status channel is closed exactly once on the producer side. The defer-close is load-bearing:
+// buildkit's client is contractually supposed to close the channel when Solve returns, but
+// variants in the wild (dropped gRPC stream after the final push, internal panic, etc.) leave the
+// channel unclosed — which hangs the consumer forever and is the root cause of the
+// "ImageBuild stuck in Running after push completes" symptom. The consumer uses the errgroup
+// context so it also unblocks on sibling cancellation.
+func runProgressSolve(
+	ctx context.Context,
+	solve func(ctx context.Context, ch chan *bkclient.SolveStatus) error,
+	consume func(ctx context.Context, ch chan *bkclient.SolveStatus) error,
+) error {
+	ch := make(chan *bkclient.SolveStatus)
+	var closeOnce sync.Once
+	closeCh := func() { closeOnce.Do(func() { close(ch) }) }
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error { return consume(egCtx, ch) })
+	eg.Go(func() error {
+		defer closeCh()
+		return solve(egCtx, ch)
+	})
+	return eg.Wait()
+}
+
 func (c *Client) runSolve(ctx context.Context, so bkclient.SolveOpt) (string, error) {
 	lw := &LogWriter{Logger: c.log}
-	ch := make(chan *bkclient.SolveStatus)
-	eg, ctx := errgroup.WithContext(ctx)
 
 	d, err := progressui.NewDisplay(lw, progressui.PlainMode)
 	if err != nil {
 		return "", fmt.Errorf("unable to setup buildkit logging: %w", err)
 	}
 
-	//nolint:contextcheck
-	eg.Go(func() error {
-		// this operation should return cleanly when solve returns (either by itself or when cancelled) so there's no
-		// need to cancel it explicitly. see https://github.com/moby/buildkit/pull/1721 for details.
-		_, err = d.UpdateFrom(context.Background(), ch)
-		return err
-	})
-
 	var imageName string
-
-	eg.Go(func() error {
-		res, err := c.bk.Solve(ctx, nil, so, ch)
-		if err != nil {
+	err = runProgressSolve(ctx,
+		func(ctx context.Context, ch chan *bkclient.SolveStatus) error {
+			res, err := c.bk.Solve(ctx, nil, so, ch)
+			if err != nil {
+				return err
+			}
+			c.log.Info("Solve complete")
+			imageName = res.ExporterResponse["image.name"]
+			return nil
+		},
+		func(ctx context.Context, ch chan *bkclient.SolveStatus) error {
+			_, err := d.UpdateFrom(ctx, ch)
 			return err
-		}
-
-		c.log.Info("Solve complete")
-		imageName = res.ExporterResponse["image.name"]
-
-		return nil
-	})
-
-	if err := eg.Wait(); err != nil {
+		},
+	)
+	if err != nil {
 		c.log.Info(fmt.Sprintf("Build failed: %s", err.Error()))
 		return "", fmt.Errorf("buildkit solve issue: %w", err)
 	}

--- a/pkg/buildkit/buildkit_test.go
+++ b/pkg/buildkit/buildkit_test.go
@@ -1,0 +1,97 @@
+package buildkit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	bkclient "github.com/moby/buildkit/client"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunProgressSolve_ProducerForgetsToCloseChannel verifies the root-cause fix for the
+// "ImageBuild stuck in Running after push completes" bug. Buildkit's client is supposed to close
+// the progress channel when Solve returns, but in production we've observed it returning without
+// closing — which used to hang the consumer forever. The sync.Once close guard in
+// runProgressSolve must unblock the consumer so the whole operation returns cleanly.
+func TestRunProgressSolve_ProducerForgetsToCloseChannel(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err := runProgressSolve(
+			context.Background(),
+			func(_ context.Context, _ chan *bkclient.SolveStatus) error {
+				// simulate buildkit "forgetting" to close the channel: return nil without sending
+				// anything and without closing.
+				return nil
+			},
+			func(_ context.Context, ch chan *bkclient.SolveStatus) error {
+				// drain until closed. Before the fix this blocks forever.
+				for range ch {
+				}
+				return nil
+			},
+		)
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runProgressSolve hung: producer returned without closing channel and consumer never unblocked")
+	}
+}
+
+// TestRunProgressSolve_ProducerErrorStillCloses verifies the guard also triggers on the error path.
+func TestRunProgressSolve_ProducerErrorStillCloses(t *testing.T) {
+	sentinel := errors.New("solve failed")
+
+	done := make(chan struct{})
+	var gotErr error
+	go func() {
+		defer close(done)
+		gotErr = runProgressSolve(
+			context.Background(),
+			func(_ context.Context, _ chan *bkclient.SolveStatus) error {
+				return sentinel
+			},
+			func(_ context.Context, ch chan *bkclient.SolveStatus) error {
+				for range ch {
+				}
+				return nil
+			},
+		)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runProgressSolve hung on producer error path")
+	}
+	require.ErrorIs(t, gotErr, sentinel)
+}
+
+// TestRunProgressSolve_ConsumerReceivesUpdates is a smoke test that the happy path still works:
+// producer sends status updates, closes the channel, both goroutines exit cleanly.
+func TestRunProgressSolve_ConsumerReceivesUpdates(t *testing.T) {
+	var received int
+
+	err := runProgressSolve(
+		context.Background(),
+		func(_ context.Context, ch chan *bkclient.SolveStatus) error {
+			for i := 0; i < 3; i++ {
+				ch <- &bkclient.SolveStatus{}
+			}
+			return nil
+		},
+		func(_ context.Context, ch chan *bkclient.SolveStatus) error {
+			for range ch {
+				received++
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, received)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,6 +120,10 @@ type Buildkit struct {
 	// FetchAndExtractTimeout used when processing the remote Docker context tarball.
 	// Fetch retries have a hard timeout limit of 4.25 mins because, come on, don't be ridiculous.
 	FetchAndExtractTimeout time.Duration `json:"fetchAndExtractTimeout" yaml:"fetchAndExtractTimeout"`
+	// BuildTimeout caps the total duration of a single buildkit Solve call. Zero means no timeout.
+	// Bounds the blast radius of a hung gRPC stream or stuck progress consumer so the buildkit worker lease
+	// is always released and the ImageBuild never gets stuck in Running indefinitely.
+	BuildTimeout time.Duration `json:"buildTimeout" yaml:"buildTimeout"`
 }
 
 // RegistryConfig options used to relax registry push/pull restrictions.

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -85,7 +85,10 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 	case hephv1.PhaseInitializing, hephv1.PhaseRunning:
 		var err error
 		if _, running := c.cancels.Load(obj.ObjectKey()); !running {
-			err = c.phase.SetFailed(coreCtx, obj, errNotRunning)
+			age := runningAge(obj)
+			log.Info("Failing orphaned build with no in-memory cancel",
+				"phase", obj.Status.Phase, "runningAge", age)
+			err = c.phase.SetFailed(coreCtx, obj, fmt.Errorf("%w (running for %s)", errNotRunning, age))
 		}
 		return ctrl.Result{}, err
 
@@ -245,7 +248,14 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 
 	// best effort phase change regardless if the original context is "done"
 	coreCtx.Context = context.Background()
-	imageName, err := bk.Build(buildCtx, buildOpts)
+
+	solveCtx := buildCtx
+	if c.cfg.BuildTimeout > 0 {
+		var cancelTimeout context.CancelFunc
+		solveCtx, cancelTimeout = context.WithTimeout(buildCtx, c.cfg.BuildTimeout)
+		defer cancelTimeout()
+	}
+	imageName, err := bk.Build(solveCtx, buildOpts)
 	if err != nil {
 		// if the underlying buildkit pod is terminated via resource delete, then buildCtx will be closed and there will
 		// be an error on it. otherwise, some external event (e.g. pod terminated) cancelled the build, so we should
@@ -255,6 +265,15 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			txn.AddAttribute("cancelled", true)
 
 			return ctrl.Result{}, nil
+		}
+
+		if errors.Is(err, context.DeadlineExceeded) || (solveCtx.Err() == context.DeadlineExceeded) {
+			buildLog.Error(err, "Build exceeded configured timeout", "timeout", c.cfg.BuildTimeout)
+			txn.NoticeError(newrelic.Error{
+				Message: err.Error(),
+				Class:   "BuildTimeoutError",
+			})
+			return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build exceeded timeout %s: %w", c.cfg.BuildTimeout, err))
 		}
 
 		buildLog.Error(err, fmt.Sprintf("Failed to build image: %s", err.Error()))
@@ -278,6 +297,27 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 
 	c.phase.SetSucceeded(coreCtx, obj)
 	return ctrl.Result{}, nil
+}
+
+// runningAge returns the time since the most recent transition into Running (or
+// Initializing, whichever is latest). Returns "unknown" if no such transition is
+// recorded on the object. Used to annotate the orphan-build failure message so
+// post-mortems can distinguish "killed by manager restart of a fresh build" from
+// "stale build that was already stuck before the restart".
+func runningAge(obj *hephv1.ImageBuild) string {
+	var latest time.Time
+	for _, t := range obj.Status.Transitions {
+		if t.Phase != hephv1.PhaseRunning && t.Phase != hephv1.PhaseInitializing {
+			continue
+		}
+		if t.OccurredAt.Time.After(latest) {
+			latest = t.OccurredAt.Time
+		}
+	}
+	if latest.IsZero() {
+		return "unknown"
+	}
+	return time.Since(latest).Truncate(time.Second).String()
 }
 
 func (c *BuildDispatcherComponent) processCancellations(log logr.Logger) {

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -73,7 +73,7 @@ func (c *BuildDispatcherComponent) Initialize(ctx *core.Context, _ *ctrl.Builder
 	return nil
 }
 
-//nolint:funlen
+//nolint:funlen,maintidx
 func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result, error) {
 	obj := coreCtx.Object.(*hephv1.ImageBuild)
 
@@ -257,7 +257,15 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 	}
 	imageName, err := bk.Build(solveCtx, buildOpts)
 	if err != nil {
-		return c.handleBuildError(coreCtx, obj, buildCtx, solveCtx, txn, log, buildLog, err)
+		// buildCtx is closed when the ImageBuild is deleted or the cancellation handler fires
+		// (see processCancellations). In that case the build was intentionally aborted, so suppress
+		// the error so the CR doesn't go into Failed on user-initiated cancellation.
+		if buildCtx.Err() != nil {
+			log.Info("Build cancelled via resource delete")
+			txn.AddAttribute("cancelled", true)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, c.failBuild(solveCtx, coreCtx, obj, txn, buildLog, err)
 	}
 	obj.Status.BuildTime = time.Since(start).Truncate(time.Millisecond).String()
 	buildSeg.End()
@@ -274,36 +282,27 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 	return ctrl.Result{}, nil
 }
 
-// handleBuildError categorizes a bk.Build error into resource-delete (no-op), timeout, or
-// generic build failure, and routes it to the appropriate phase transition + New Relic class.
-// Split out of Reconcile to keep that function under the maintainability-index linter threshold.
-func (c *BuildDispatcherComponent) handleBuildError(
+// failBuild categorizes a non-cancellation bk.Build error into timeout or generic build failure
+// and routes it to the appropriate phase transition + New Relic class. Split out of Reconcile to
+// keep that function under the maintainability-index linter threshold.
+func (c *BuildDispatcherComponent) failBuild(
+	solveCtx context.Context,
 	coreCtx *core.Context,
 	obj *hephv1.ImageBuild,
-	buildCtx, solveCtx context.Context,
 	txn *newrelic.Transaction,
-	log, buildLog logr.Logger,
+	buildLog logr.Logger,
 	err error,
-) (ctrl.Result, error) {
-	// if the underlying buildkit pod is terminated via resource delete, then buildCtx will be closed
-	// and there will be an error on it. otherwise, some external event (e.g. pod terminated)
-	// cancelled the build, so we should mark the build as failed.
-	if buildCtx.Err() != nil {
-		log.Info("Build cancelled via resource delete")
-		txn.AddAttribute("cancelled", true)
-		return ctrl.Result{}, nil
-	}
-
+) error {
 	if errors.Is(err, context.DeadlineExceeded) || solveCtx.Err() == context.DeadlineExceeded {
 		buildLog.Error(err, "Build exceeded configured timeout", "timeout", c.cfg.BuildTimeout)
 		txn.NoticeError(newrelic.Error{Message: err.Error(), Class: "BuildTimeoutError"})
 		wrapped := fmt.Errorf("build exceeded timeout %s: %w", c.cfg.BuildTimeout, err)
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, wrapped)
+		return c.phase.SetFailed(coreCtx, obj, wrapped)
 	}
 
 	buildLog.Error(err, fmt.Sprintf("Failed to build image: %s", err.Error()))
 	txn.NoticeError(newrelic.Error{Message: err.Error(), Class: "ImageBuildError"})
-	return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build failed: %w", err))
+	return c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build failed: %w", err))
 }
 
 // runningAge returns the time since the most recent transition into Running (or

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -257,32 +257,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 	}
 	imageName, err := bk.Build(solveCtx, buildOpts)
 	if err != nil {
-		// if the underlying buildkit pod is terminated via resource delete, then buildCtx will be closed and there will
-		// be an error on it. otherwise, some external event (e.g. pod terminated) cancelled the build, so we should
-		// mark the build as failed.
-		if buildCtx.Err() != nil {
-			log.Info("Build cancelled via resource delete")
-			txn.AddAttribute("cancelled", true)
-
-			return ctrl.Result{}, nil
-		}
-
-		if errors.Is(err, context.DeadlineExceeded) || (solveCtx.Err() == context.DeadlineExceeded) {
-			buildLog.Error(err, "Build exceeded configured timeout", "timeout", c.cfg.BuildTimeout)
-			txn.NoticeError(newrelic.Error{
-				Message: err.Error(),
-				Class:   "BuildTimeoutError",
-			})
-			return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build exceeded timeout %s: %w", c.cfg.BuildTimeout, err))
-		}
-
-		buildLog.Error(err, fmt.Sprintf("Failed to build image: %s", err.Error()))
-
-		txn.NoticeError(newrelic.Error{
-			Message: err.Error(),
-			Class:   "ImageBuildError",
-		})
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build failed: %w", err))
+		return c.handleBuildError(coreCtx, obj, buildCtx, solveCtx, txn, log, buildLog, err)
 	}
 	obj.Status.BuildTime = time.Since(start).Truncate(time.Millisecond).String()
 	buildSeg.End()
@@ -299,6 +274,38 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 	return ctrl.Result{}, nil
 }
 
+// handleBuildError categorizes a bk.Build error into resource-delete (no-op), timeout, or
+// generic build failure, and routes it to the appropriate phase transition + New Relic class.
+// Split out of Reconcile to keep that function under the maintainability-index linter threshold.
+func (c *BuildDispatcherComponent) handleBuildError(
+	coreCtx *core.Context,
+	obj *hephv1.ImageBuild,
+	buildCtx, solveCtx context.Context,
+	txn *newrelic.Transaction,
+	log, buildLog logr.Logger,
+	err error,
+) (ctrl.Result, error) {
+	// if the underlying buildkit pod is terminated via resource delete, then buildCtx will be closed
+	// and there will be an error on it. otherwise, some external event (e.g. pod terminated)
+	// cancelled the build, so we should mark the build as failed.
+	if buildCtx.Err() != nil {
+		log.Info("Build cancelled via resource delete")
+		txn.AddAttribute("cancelled", true)
+		return ctrl.Result{}, nil
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) || solveCtx.Err() == context.DeadlineExceeded {
+		buildLog.Error(err, "Build exceeded configured timeout", "timeout", c.cfg.BuildTimeout)
+		txn.NoticeError(newrelic.Error{Message: err.Error(), Class: "BuildTimeoutError"})
+		wrapped := fmt.Errorf("build exceeded timeout %s: %w", c.cfg.BuildTimeout, err)
+		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, wrapped)
+	}
+
+	buildLog.Error(err, fmt.Sprintf("Failed to build image: %s", err.Error()))
+	txn.NoticeError(newrelic.Error{Message: err.Error(), Class: "ImageBuildError"})
+	return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build failed: %w", err))
+}
+
 // runningAge returns the time since the most recent transition into Running (or
 // Initializing, whichever is latest). Returns "unknown" if no such transition is
 // recorded on the object. Used to annotate the orphan-build failure message so
@@ -310,7 +317,7 @@ func runningAge(obj *hephv1.ImageBuild) string {
 		if t.Phase != hephv1.PhaseRunning && t.Phase != hephv1.PhaseInitializing {
 			continue
 		}
-		if t.OccurredAt.Time.After(latest) {
+		if t.OccurredAt.After(latest) {
 			latest = t.OccurredAt.Time
 		}
 	}

--- a/pkg/controller/imagebuild/component/builddispatcher_test.go
+++ b/pkg/controller/imagebuild/component/builddispatcher_test.go
@@ -1,0 +1,55 @@
+package component
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
+)
+
+func TestRunningAge_NoTransitions(t *testing.T) {
+	ib := &hephv1.ImageBuild{}
+	if got := runningAge(ib); got != "unknown" {
+		t.Fatalf("expected unknown, got %q", got)
+	}
+}
+
+func TestRunningAge_OnlySucceededTransition(t *testing.T) {
+	ib := &hephv1.ImageBuild{
+		Status: hephv1.ImageBuildStatus{
+			Transitions: []hephv1.ImageBuildTransition{
+				{Phase: hephv1.PhaseSucceeded, OccurredAt: metav1.Time{Time: time.Now().Add(-time.Hour)}},
+			},
+		},
+	}
+	if got := runningAge(ib); got != "unknown" {
+		t.Fatalf("expected unknown (no Running/Initializing transition), got %q", got)
+	}
+}
+
+func TestRunningAge_LatestRunningUsed(t *testing.T) {
+	now := time.Now()
+	ib := &hephv1.ImageBuild{
+		Status: hephv1.ImageBuildStatus{
+			Transitions: []hephv1.ImageBuildTransition{
+				{Phase: hephv1.PhaseInitializing, OccurredAt: metav1.Time{Time: now.Add(-10 * time.Minute)}},
+				{Phase: hephv1.PhaseRunning, OccurredAt: metav1.Time{Time: now.Add(-5 * time.Minute)}},
+				{Phase: hephv1.PhaseFailed, OccurredAt: metav1.Time{Time: now.Add(-time.Minute)}},
+			},
+		},
+	}
+	got := runningAge(ib)
+	if got == "unknown" {
+		t.Fatalf("expected a duration, got unknown")
+	}
+	d, err := time.ParseDuration(got)
+	if err != nil {
+		t.Fatalf("result %q is not a duration: %v", got, err)
+	}
+	// should be ~5m, bounded loosely to tolerate test scheduling jitter
+	if d < 4*time.Minute || d > 6*time.Minute {
+		t.Fatalf("expected ~5m, got %s", d)
+	}
+}


### PR DESCRIPTION
### Summary

Fixes an intermittent bug where ImageBuild CRs get stuck in Running after buildkit successfully builds and pushes the image — leaving the buildkit worker leased, blocking scale-down, and queuing subsequent builds.

Root cause: runSolve in pkg/buildkit/buildkit.go relies on buildkit's client to close the SolveStatus channel after Solve() returns. When that close is skipped (dropped gRPC stream, internal panic, etc.), the progress consumer blocks on <-ch forever, errgroup.Wait() never returns, the worker is never released, and the Succeeded transition is never generated.

### Changes

- pkg/buildkit/buildkit.go — extracted runProgressSolve helper that defer-closes the status channel via sync.Once on the producer side. Consumer now runs under the errgroup context so it also unblocks on sibling cancellation.
- pkg/config/config.go + helm chart — new buildTimeout config caps the total bk.Build duration. Deadline exceeded is surfaced as BuildTimeoutError in New Relic and transitions the CR to Failed, guaranteeing the worker lease is always released.
- pkg/controller/imagebuild/component/builddispatcher.go — annotate the existing orphan-build-on-restart log/error with the Running transition age for post-mortem observability.
- Tests — unit tests that would deadlock without the fix prove the channel-close safety net works on the happy path, the producer-error path, and when the producer returns without closing.
