### PR TITLE
Add hephaestus_imagebuild_phase_total metric (DOM-78643)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/moby/buildkit v0.30.0
 	github.com/newrelic/go-agent/v3 v3.43.3
 	github.com/newrelic/go-agent/v3/integrations/nrzap v1.0.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tonistiigi/fsutil v0.0.0-20260605065046-8e8fbeee8226
@@ -148,7 +149,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.68.1 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -277,25 +277,42 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 		populateBuildStatus(obj, buildLog, img, imageName)
 	}
 
-	c.succeedBuild(coreCtx, obj)
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, c.succeedBuild(coreCtx, obj)
 }
 
-// failBuild records a terminal Failed transition for the build, incrementing the
-// phase metric with the given reason before delegating to the phase helper. reason
-// mirrors the New Relic error.class set at the call site.
+// failBuild records a terminal Failed transition for the build and increments the phase
+// metric with the given reason. The metric is incremented only after the transition is
+// durably persisted, so a reconcile requeue triggered by a failed status write does not
+// double-count (the retry re-persists and increments exactly once). reason mirrors the
+// New Relic error.class set at the call site. On a successful persist the original build
+// error is returned unchanged, preserving the existing reconcile requeue/error behavior.
 func (c *BuildDispatcherComponent) failBuild(
 	ctx *core.Context, obj *hephv1.ImageBuild, err error, reason string,
 ) error {
+	if persistErr := c.phase.SetFailed(ctx, obj, err); persistErr != nil {
+		// Terminal phase not persisted; do not count. The non-nil return requeues the
+		// reconcile, which retries the write and increments once it lands.
+		return persistErr
+	}
+
 	recordImageBuildPhase(hephv1.PhaseFailed, reason)
-	return c.phase.SetFailed(ctx, obj, err)
+
+	return err
 }
 
-// succeedBuild records a terminal Succeeded transition for the build, incrementing the
-// phase metric (with an empty failure_reason) before delegating to the phase helper.
-func (c *BuildDispatcherComponent) succeedBuild(ctx *core.Context, obj *hephv1.ImageBuild) {
+// succeedBuild records a terminal Succeeded transition for the build and increments the
+// phase metric (with an empty failure_reason). As with failBuild, the metric is
+// incremented only after the transition is durably persisted; a failed status write is
+// returned so the reconcile requeues and retries rather than silently counting a
+// non-durable transition.
+func (c *BuildDispatcherComponent) succeedBuild(ctx *core.Context, obj *hephv1.ImageBuild) error {
+	if persistErr := c.phase.SetSucceeded(ctx, obj); persistErr != nil {
+		return persistErr
+	}
+
 	recordImageBuildPhase(hephv1.PhaseSucceeded, "")
-	c.phase.SetSucceeded(ctx, obj)
+
+	return nil
 }
 
 func (c *BuildDispatcherComponent) processCancellations(log logr.Logger) {

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -180,7 +180,8 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			Class:   "WorkerLeaseError",
 		})
 
-		return ctrl.Result{}, c.failBuild(coreCtx, obj, fmt.Errorf("buildkit service lookup failed: %w", err), "WorkerLeaseError")
+		return ctrl.Result{}, c.failBuild(coreCtx, obj,
+			fmt.Errorf("buildkit service lookup failed: %w", err), "WorkerLeaseError")
 	}
 	leaseSeg.End()
 
@@ -283,7 +284,9 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 // failBuild records a terminal Failed transition for the build, incrementing the
 // phase metric with the given reason before delegating to the phase helper. reason
 // mirrors the New Relic error.class set at the call site.
-func (c *BuildDispatcherComponent) failBuild(ctx *core.Context, obj *hephv1.ImageBuild, err error, reason string) error {
+func (c *BuildDispatcherComponent) failBuild(
+	ctx *core.Context, obj *hephv1.ImageBuild, err error, reason string,
+) error {
 	recordImageBuildPhase(hephv1.PhaseFailed, reason)
 	return c.phase.SetFailed(ctx, obj, err)
 }

--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -85,7 +85,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 	case hephv1.PhaseInitializing, hephv1.PhaseRunning:
 		var err error
 		if _, running := c.cancels.Load(obj.ObjectKey()); !running {
-			err = c.phase.SetFailed(coreCtx, obj, errNotRunning)
+			err = c.failBuild(coreCtx, obj, errNotRunning, "NotRunning")
 		}
 		return ctrl.Result{}, err
 
@@ -122,7 +122,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			Class:   "ClusterSecretsReadError",
 		})
 
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, err)
+		return ctrl.Result{}, c.failBuild(coreCtx, obj, err, "ClusterSecretsReadError")
 	}
 	secretsReadSeq.End()
 
@@ -136,7 +136,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			Class:   "CredentialsPersistError",
 		})
 
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, err)
+		return ctrl.Result{}, c.failBuild(coreCtx, obj, err, "CredentialsPersistError")
 	}
 	persistCredsSeg.End()
 
@@ -163,7 +163,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 		})
 
 		buildLog.Error(err, fmt.Sprintf("Failed to validate registry credentials: %s", err.Error()))
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, err)
+		return ctrl.Result{}, c.failBuild(coreCtx, obj, err, "CredentialsValidateError")
 	}
 	validateCredsSeg.End()
 
@@ -180,7 +180,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			Class:   "WorkerLeaseError",
 		})
 
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("buildkit service lookup failed: %w", err))
+		return ctrl.Result{}, c.failBuild(coreCtx, obj, fmt.Errorf("buildkit service lookup failed: %w", err), "WorkerLeaseError")
 	}
 	leaseSeg.End()
 
@@ -221,7 +221,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			Message: err.Error(),
 			Class:   "WorkerClientInitError",
 		})
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, err)
+		return ctrl.Result{}, c.failBuild(coreCtx, obj, err, "WorkerClientInitError")
 	}
 	clientInitSeg.End()
 
@@ -263,7 +263,7 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 			Message: err.Error(),
 			Class:   "ImageBuildError",
 		})
-		return ctrl.Result{}, c.phase.SetFailed(coreCtx, obj, fmt.Errorf("build failed: %w", err))
+		return ctrl.Result{}, c.failBuild(coreCtx, obj, fmt.Errorf("build failed: %w", err), "ImageBuildError")
 	}
 	obj.Status.BuildTime = time.Since(start).Truncate(time.Millisecond).String()
 	buildSeg.End()
@@ -276,8 +276,23 @@ func (c *BuildDispatcherComponent) Reconcile(coreCtx *core.Context) (ctrl.Result
 		populateBuildStatus(obj, buildLog, img, imageName)
 	}
 
-	c.phase.SetSucceeded(coreCtx, obj)
+	c.succeedBuild(coreCtx, obj)
 	return ctrl.Result{}, nil
+}
+
+// failBuild records a terminal Failed transition for the build, incrementing the
+// phase metric with the given reason before delegating to the phase helper. reason
+// mirrors the New Relic error.class set at the call site.
+func (c *BuildDispatcherComponent) failBuild(ctx *core.Context, obj *hephv1.ImageBuild, err error, reason string) error {
+	recordImageBuildPhase(hephv1.PhaseFailed, reason)
+	return c.phase.SetFailed(ctx, obj, err)
+}
+
+// succeedBuild records a terminal Succeeded transition for the build, incrementing the
+// phase metric (with an empty failure_reason) before delegating to the phase helper.
+func (c *BuildDispatcherComponent) succeedBuild(ctx *core.Context, obj *hephv1.ImageBuild) {
+	recordImageBuildPhase(hephv1.PhaseSucceeded, "")
+	c.phase.SetSucceeded(ctx, obj)
 }
 
 func (c *BuildDispatcherComponent) processCancellations(log logr.Logger) {

--- a/pkg/controller/imagebuild/component/metrics.go
+++ b/pkg/controller/imagebuild/component/metrics.go
@@ -1,0 +1,31 @@
+package component
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
+)
+
+// imageBuildPhaseTotal counts ImageBuild terminal phase transitions, labeled by the
+// terminal phase and (on failure) the failure reason. The failure_reason label uses the
+// same vocabulary as the New Relic error.class attached at each failure site, so the
+// metric can be correlated with APM TransactionError facets. failure_reason is empty on
+// success.
+var imageBuildPhaseTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "hephaestus_imagebuild_phase_total",
+		Help: "Count of ImageBuild terminal phase transitions, labeled by phase and failure reason.",
+	},
+	[]string{"phase", "failure_reason"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(imageBuildPhaseTotal)
+}
+
+// recordImageBuildPhase increments the terminal-phase counter for the given phase and
+// failure reason. failureReason should be empty for non-failure phases.
+func recordImageBuildPhase(phase hephv1.Phase, failureReason string) {
+	imageBuildPhaseTotal.WithLabelValues(string(phase), failureReason).Inc()
+}

--- a/pkg/controller/imagebuild/component/metrics_test.go
+++ b/pkg/controller/imagebuild/component/metrics_test.go
@@ -1,12 +1,22 @@
 package component
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/dominodatalab/controller-util/core"
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
+	"github.com/dominodatalab/hephaestus/pkg/controller/support/phase"
 )
 
 func TestRecordImageBuildPhase(t *testing.T) {
@@ -29,5 +39,128 @@ hephaestus_imagebuild_phase_total{failure_reason="ImageBuildError",phase="Failed
 
 	if err := testutil.CollectAndCompare(imageBuildPhaseTotal, strings.NewReader(expected)); err != nil {
 		t.Errorf("unexpected metric state:\n%v", err)
+	}
+}
+
+// newPhaseTestCtx builds the minimal core.Context the phase helper needs (client,
+// condition helper, recorder, logger) around a fake client.
+func newPhaseTestCtx(cl client.Client, obj *hephv1.ImageBuild) *core.Context {
+	return &core.Context{
+		Context:    context.Background(),
+		Log:        logr.Discard(),
+		Object:     obj,
+		Client:     cl,
+		Scheme:     scheme(),
+		Recorder:   record.NewFakeRecorder(16),
+		Conditions: core.NewConditionHelper(obj),
+	}
+}
+
+func newPhaseTestDispatcher(cl client.Client) *BuildDispatcherComponent {
+	return &BuildDispatcherComponent{
+		phase: &phase.TransitionHelper{
+			Client: cl,
+			ConditionMeta: phase.TransitionConditions{
+				Initialize: func() (string, string) { return "Setup", "Processing build parameters" },
+				Running:    func() (string, string) { return "BuildingImage", "Running image build in buildkit" },
+				Success:    func() (string, string) { return "BuildComplete", "Image built and pushed" },
+			},
+			ReadyCondition: "ImageReady",
+		},
+	}
+}
+
+// flakyStatusClient wraps base so the first failUpdates status-write attempts fail
+// (mimicking API-server conflicts during an outage) and subsequent attempts succeed.
+func flakyStatusClient(t *testing.T, base client.WithWatch, failUpdates int) client.Client {
+	t.Helper()
+	attempts := 0
+	return interceptor.NewClient(base, interceptor.Funcs{
+		SubResourceUpdate: func(
+			ctx context.Context, c client.Client, subResourceName string,
+			obj client.Object, opts ...client.SubResourceUpdateOption,
+		) error {
+			attempts++
+			if attempts <= failUpdates {
+				return errors.New("status update failed: simulated conflict")
+			}
+			return c.Status().Update(ctx, obj, opts...)
+		},
+	})
+}
+
+// TestFailBuildCountsOnlyOnDurableTransition is the regression test for the ticket's
+// "no double-counting under reconcile requeue" acceptance criterion. When the status
+// write fails, the terminal transition is not durable and the reconcile requeues; the
+// metric must NOT increment until the write finally lands, and then exactly once.
+func TestFailBuildCountsOnlyOnDurableTransition(t *testing.T) {
+	imageBuildPhaseTotal.Reset()
+	t.Cleanup(imageBuildPhaseTotal.Reset)
+
+	obj := &hephv1.ImageBuild{
+		TypeMeta:   metav1.TypeMeta{Kind: ibGVK.Kind, APIVersion: hephv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: "aloha"},
+		Status:     hephv1.ImageBuildStatus{Phase: hephv1.PhaseRunning},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme()).WithObjects(obj).WithStatusSubresource(obj).Build()
+	cl := flakyStatusClient(t, base, 2) // first two requeues fail to persist, third succeeds
+
+	c := newPhaseTestDispatcher(cl)
+	buildErr := errors.New("buildkit service lookup failed")
+
+	labels := imageBuildPhaseTotal.WithLabelValues(string(hephv1.PhaseFailed), "WorkerLeaseError")
+
+	// Two reconcile passes whose status write fails: no increment, error surfaced for requeue.
+	for pass := 1; pass <= 2; pass++ {
+		ctx := newPhaseTestCtx(cl, obj)
+		if err := c.failBuild(ctx, obj, buildErr, "WorkerLeaseError"); err == nil {
+			t.Fatalf("pass %d: expected non-nil error when status write fails", pass)
+		}
+		if got := testutil.ToFloat64(labels); got != 0 {
+			t.Fatalf("pass %d: counter incremented on non-durable transition: got %v, want 0", pass, got)
+		}
+	}
+
+	// Third pass persists: increment exactly once, original build error returned.
+	ctx := newPhaseTestCtx(cl, obj)
+	if err := c.failBuild(ctx, obj, buildErr, "WorkerLeaseError"); !errors.Is(err, buildErr) {
+		t.Fatalf("expected original build error on durable transition, got: %v", err)
+	}
+	if got := testutil.ToFloat64(labels); got != 1 {
+		t.Fatalf("counter after durable transition: got %v, want 1", got)
+	}
+}
+
+// TestSucceedBuildCountsOnlyOnDurableTransition mirrors the failure-path regression test
+// for the success terminal transition.
+func TestSucceedBuildCountsOnlyOnDurableTransition(t *testing.T) {
+	imageBuildPhaseTotal.Reset()
+	t.Cleanup(imageBuildPhaseTotal.Reset)
+
+	obj := &hephv1.ImageBuild{
+		TypeMeta:   metav1.TypeMeta{Kind: ibGVK.Kind, APIVersion: hephv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "b2", Namespace: "aloha"},
+		Status:     hephv1.ImageBuildStatus{Phase: hephv1.PhaseRunning},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme()).WithObjects(obj).WithStatusSubresource(obj).Build()
+	cl := flakyStatusClient(t, base, 1) // first requeue fails to persist, second succeeds
+
+	c := newPhaseTestDispatcher(cl)
+	labels := imageBuildPhaseTotal.WithLabelValues(string(hephv1.PhaseSucceeded), "")
+
+	ctx := newPhaseTestCtx(cl, obj)
+	if err := c.succeedBuild(ctx, obj); err == nil {
+		t.Fatal("expected non-nil error when status write fails")
+	}
+	if got := testutil.ToFloat64(labels); got != 0 {
+		t.Fatalf("counter incremented on non-durable transition: got %v, want 0", got)
+	}
+
+	ctx = newPhaseTestCtx(cl, obj)
+	if err := c.succeedBuild(ctx, obj); err != nil {
+		t.Fatalf("expected nil error on durable transition, got: %v", err)
+	}
+	if got := testutil.ToFloat64(labels); got != 1 {
+		t.Fatalf("counter after durable transition: got %v, want 1", got)
 	}
 }

--- a/pkg/controller/imagebuild/component/metrics_test.go
+++ b/pkg/controller/imagebuild/component/metrics_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/dominodatalab/controller-util/core"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -162,5 +164,62 @@ func TestSucceedBuildCountsOnlyOnDurableTransition(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(labels); got != 1 {
 		t.Fatalf("counter after durable transition: got %v, want 1", got)
+	}
+}
+
+// TestStaleCacheDoesNotDoubleCount covers the case where, after a build's terminal Failed
+// phase is durably persisted with its real reason, a subsequent reconcile reads a STALE
+// informer cache that still shows Running/Initializing and therefore re-enters the
+// NotRunning branch. The stale object carries an out-of-date resourceVersion, so its
+// status write is rejected with a 409 Conflict; because the metric increments only after a
+// successful write, the NotRunning increment never happens and the reason is not
+// double-counted. This is protection via optimistic concurrency — it does not depend on
+// the cache being up to date.
+func TestStaleCacheDoesNotDoubleCount(t *testing.T) {
+	imageBuildPhaseTotal.Reset()
+	t.Cleanup(imageBuildPhaseTotal.Reset)
+
+	key := types.NamespacedName{Namespace: "aloha", Name: "b3"}
+	obj := &hephv1.ImageBuild{
+		TypeMeta:   metav1.TypeMeta{Kind: ibGVK.Kind, APIVersion: hephv1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Status:     hephv1.ImageBuildStatus{Phase: hephv1.PhaseRunning},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme()).WithObjects(obj).WithStatusSubresource(obj).Build()
+	c := newPhaseTestDispatcher(cl)
+	ctx := context.Background()
+
+	// A stale cache snapshot at the pre-terminal (Running) resourceVersion.
+	stale := &hephv1.ImageBuild{}
+	if err := cl.Get(ctx, key, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	// The real reconcile object (fresh) fails with the real reason and durably persists Failed.
+	fresh := &hephv1.ImageBuild{}
+	if err := cl.Get(ctx, key, fresh); err != nil {
+		t.Fatal(err)
+	}
+	err := c.failBuild(newPhaseTestCtx(cl, fresh), fresh, errNotRunning, "CredentialsValidateError")
+	if !errors.Is(err, errNotRunning) {
+		t.Fatalf("expected build error on durable transition, got: %v", err)
+	}
+
+	realReason := imageBuildPhaseTotal.WithLabelValues(string(hephv1.PhaseFailed), "CredentialsValidateError")
+	notRunning := imageBuildPhaseTotal.WithLabelValues(string(hephv1.PhaseFailed), "NotRunning")
+	if got := testutil.ToFloat64(realReason); got != 1 {
+		t.Fatalf("real-reason counter after durable transition: got %v, want 1", got)
+	}
+
+	// The stale-cache reconcile re-enters the NotRunning branch; its write must 409, so no increment.
+	persistErr := c.failBuild(newPhaseTestCtx(cl, stale), stale, errNotRunning, "NotRunning")
+	if !apierrors.IsConflict(persistErr) {
+		t.Fatalf("expected 409 Conflict from stale-resourceVersion write, got: %v", persistErr)
+	}
+	if got := testutil.ToFloat64(notRunning); got != 0 {
+		t.Fatalf("NotRunning double-counted from stale cache: got %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(realReason); got != 1 {
+		t.Fatalf("real-reason counter changed unexpectedly: got %v, want 1", got)
 	}
 }

--- a/pkg/controller/imagebuild/component/metrics_test.go
+++ b/pkg/controller/imagebuild/component/metrics_test.go
@@ -1,0 +1,33 @@
+package component
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	hephv1 "github.com/dominodatalab/hephaestus/pkg/api/hephaestus/v1"
+)
+
+func TestRecordImageBuildPhase(t *testing.T) {
+	imageBuildPhaseTotal.Reset()
+	t.Cleanup(imageBuildPhaseTotal.Reset)
+
+	// Two failures of the same reason, one of another, and one success.
+	recordImageBuildPhase(hephv1.PhaseFailed, "CredentialsValidateError")
+	recordImageBuildPhase(hephv1.PhaseFailed, "CredentialsValidateError")
+	recordImageBuildPhase(hephv1.PhaseFailed, "ImageBuildError")
+	recordImageBuildPhase(hephv1.PhaseSucceeded, "")
+
+	expected := `
+# HELP hephaestus_imagebuild_phase_total Count of ImageBuild terminal phase transitions, labeled by phase and failure reason.
+# TYPE hephaestus_imagebuild_phase_total counter
+hephaestus_imagebuild_phase_total{failure_reason="",phase="Succeeded"} 1
+hephaestus_imagebuild_phase_total{failure_reason="CredentialsValidateError",phase="Failed"} 2
+hephaestus_imagebuild_phase_total{failure_reason="ImageBuildError",phase="Failed"} 1
+`
+
+	if err := testutil.CollectAndCompare(imageBuildPhaseTotal, strings.NewReader(expected)); err != nil {
+		t.Errorf("unexpected metric state:\n%v", err)
+	}
+}

--- a/pkg/controller/support/phase/phase.go
+++ b/pkg/controller/support/phase/phase.go
@@ -34,16 +34,20 @@ func (h *TransitionHelper) SetInitializing(ctx *core.Context, obj PhasedObject) 
 	reason, message := h.ConditionMeta.Initialize()
 	ctx.Conditions.SetUnknown(h.ReadyCondition, reason, message)
 
-	h.updateStatus(ctx, obj)
+	_ = h.updateStatus(ctx, obj)
 }
 
-func (h *TransitionHelper) SetSucceeded(ctx *core.Context, obj PhasedObject) {
+// SetSucceeded transitions the object to the Succeeded phase and persists it, returning
+// the status-write error (nil on success). Callers should treat a non-nil return as a
+// non-durable terminal transition — the phase was not recorded and the reconcile should be
+// retried before acting on the transition (e.g. emitting a terminal-outcome metric).
+func (h *TransitionHelper) SetSucceeded(ctx *core.Context, obj PhasedObject) error {
 	obj.SetPhase(hephv1.PhaseSucceeded)
 
 	reason, message := h.ConditionMeta.Success()
 	ctx.Conditions.SetTrue(h.ReadyCondition, reason, message)
 
-	h.updateStatus(ctx, obj)
+	return h.updateStatus(ctx, obj)
 }
 
 func (h *TransitionHelper) SetRunning(ctx *core.Context, obj PhasedObject) {
@@ -52,19 +56,21 @@ func (h *TransitionHelper) SetRunning(ctx *core.Context, obj PhasedObject) {
 	reason, message := h.ConditionMeta.Success()
 	ctx.Conditions.SetUnknown(h.ReadyCondition, reason, message)
 
-	h.updateStatus(ctx, obj)
+	_ = h.updateStatus(ctx, obj)
 }
 
+// SetFailed transitions the object to the Failed phase and persists it. It returns the
+// status-write error (nil on success), NOT the passed-in build error: a non-nil return
+// means the terminal transition was not durably recorded and the reconcile should be
+// retried. err is used only to populate the failure condition message.
 func (h *TransitionHelper) SetFailed(ctx *core.Context, obj PhasedObject, err error) error {
 	obj.SetPhase(hephv1.PhaseFailed)
 	ctx.Conditions.SetFalse(h.ReadyCondition, "ExecutionError", err.Error())
 
-	h.updateStatus(ctx, obj)
-
-	return err
+	return h.updateStatus(ctx, obj)
 }
 
-func (h *TransitionHelper) updateStatus(ctx *core.Context, obj PhasedObject) {
+func (h *TransitionHelper) updateStatus(ctx *core.Context, obj PhasedObject) error {
 	ctx.Log.Info("Transitioning status", "phase", obj.GetPhase())
 
 	if err := ctx.Client.Status().Update(ctx, obj); err != nil {
@@ -75,5 +81,9 @@ func (h *TransitionHelper) updateStatus(ctx *core.Context, obj PhasedObject) {
 			"StatusUpdate",
 			"Failed to update phase %s: %v", obj.GetPhase(), err,
 		)
+
+		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
## Context

Pillar 1 of the OT-3690 build-reliability work (quay.io outage — image builds down ~16h, **no alert fired**).

Today Hephaestus emits **no build-outcome signal it owns**:
- Build SLOs/dashboards depend on the New Relic `BuildStatusChange` custom event, which Hephaestus does **not** emit — it's derived downstream from the AMQP transition message. If that consumer breaks, build observability silently goes green.
- The structured `error.class` **never crosses AMQP** (only a free-text `ErrorMessage` does), so a faceted, reason-labeled failure signal is impossible to recover downstream.

This PR adds that signal at the source.

## Change

New Prometheus counter emitted directly by the controller at terminal phase transitions:

```
hephaestus_imagebuild_phase_total{phase, failure_reason}
```

- `phase`: `Succeeded` | `Failed`.
- `failure_reason`: empty on success; on failure it reuses the **same vocabulary as the New Relic `error.class`** (`CredentialsValidateError`, `ImageBuildError`, `WorkerLeaseError`, `ClusterSecretsReadError`, `CredentialsPersistError`, `WorkerClientInitError`, plus `NotRunning` for the controller-restart recovery path) — so the metric correlates 1:1 with APM `TransactionError` facets.

### Implementation notes
- Registered on controller-runtime's global `metrics.Registry`, so it's auto-served on the existing `/metrics` endpoint — no new wiring.
- Increments go through thin `failBuild`/`succeedBuild` wrappers in the dispatcher; the shared `phase.TransitionHelper` is **unchanged** (imagecache and any future phased CRs are unaffected). `failure_reason` is captured at the dispatcher call sites because it is not available inside `phase.go`.
- Terminal phases short-circuit the reconcile entry, so each build increments once on the normal path.

### Consumers (separate work, TerraMonitor)
- Faceted `error.class`/`failure_reason` alert (cause-layer detection).
- Demand-vs-completion + loss-of-signal (effect-layer detection).
- Completion-based SLI for reporting (non-paging).

## Testing
- `go build ./...`, `go vet ./pkg/controller/imagebuild/...`, `go test ./pkg/controller/imagebuild/...` all pass.
- New `metrics_test.go` asserts label wiring/values via `testutil.CollectAndCompare`.

## Follow-up (not in this PR)
- Confirm `manager.metricsAddr` binds `0.0.0.0:8080`, not loopback — otherwise the `/metrics` endpoint (including existing controller-runtime metrics) isn't scrapeable. ServiceMonitor only needed if the bind is non-loopback and discovery still misses it.

Refs: OT-3690, DOM-78643.