### PR TITLE
DOM-78638: don't fail builds when an unused registry is down

### DIFF
--- a/pkg/controller/imagebuild/component/builddispatcher.go
+++ b/pkg/controller/imagebuild/component/builddispatcher.go
@@ -308,7 +308,9 @@ func (c *BuildDispatcherComponent) prepareBuildInputs(
 	}
 
 	buildLog.Info("Validating registry credentials")
-	if err = credentials.Verify(coreCtx, configDir, insecureRegistries, helpMessage); err != nil {
+	err = credentials.Verify(coreCtx, buildLog, configDir, insecureRegistries, helpMessage,
+		slices.Concat(obj.Spec.Images, obj.Spec.ImportRemoteBuildCache))
+	if err != nil {
 		txn.NoticeError(newrelic.Error{Message: err.Error(), Class: "CredentialsValidateError"})
 
 		buildLog.Error(err, fmt.Sprintf("Failed to validate registry credentials: %s", err.Error()))

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/containerd/errdefs"
 
+	"github.com/distribution/reference"
 	typesregistry "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/go-logr/logr"
@@ -132,7 +134,44 @@ func Persist(
 	return dir, helpMessage, err
 }
 
-func Verify(ctx context.Context, configDir string, insecureRegistries []string, helpMessage []string) error {
+// normalizeRegistryHost reduces a docker config server key or an image ref
+// domain to a plain hostname so the two can be compared. Docker Hub goes by
+// several names, so they all collapse to "docker.io".
+func normalizeRegistryHost(server string) string {
+	host := registry.ConvertToHostname(server)
+	if host == "index.docker.io" || host == "registry-1.docker.io" {
+		host = "docker.io"
+	}
+
+	return host
+}
+
+// usedRegistryHosts returns the set of registry hostnames the build is known
+// to use, taken from the image refs it will push.
+func usedRegistryHosts(images []string) map[string]bool {
+	hosts := map[string]bool{}
+	for _, image := range images {
+		named, err := reference.ParseNormalizedNamed(image)
+		if err != nil {
+			// Image refs are validated by the webhook. A ref that does not
+			// parse cannot match any registry, so it adds nothing here.
+			continue
+		}
+
+		hosts[normalizeRegistryHost(reference.Domain(named))] = true
+	}
+
+	return hosts
+}
+
+func Verify(
+	ctx context.Context,
+	logger logr.Logger,
+	configDir string,
+	insecureRegistries []string,
+	helpMessage []string,
+	images []string,
+) error {
 	filename := filepath.Join(configDir, "config.json")
 	data, err := os.ReadFile(filename)
 	if err != nil {
@@ -149,25 +188,57 @@ func Verify(ctx context.Context, configDir string, insecureRegistries []string, 
 		return err
 	}
 
+	usedHosts := usedRegistryHosts(images)
+
 	var errs []error
 	for server, auth := range configJSON.Auths {
+		// Only check credentials for registries this build pushes to. A cred
+		// for any other registry cannot fail the build here, no matter its
+		// state. If no images are given, check everything.
+		if len(usedHosts) > 0 && !usedHosts[normalizeRegistryHost(server)] {
+			logger.Info("Skipping credential check for registry not used by this build", "registry", server)
+			continue
+		}
+
 		auth.ServerAddress = server
 
+		var authErr error
 		err := wait.ExponentialBackoffWithContext(ctx, defaultBackoff, func(ctx context.Context) (bool, error) {
-			if _, _, err = svc.Auth(ctx, &auth, "DominoDataLab_Hephaestus/1.0"); err != nil {
-				if errdefs.IsUnauthorized(err) {
-					return false, err
+			if _, _, authErr = svc.Auth(ctx, &auth, "DominoDataLab_Hephaestus/1.0"); authErr != nil {
+				if errdefs.IsUnauthorized(authErr) {
+					return false, authErr
 				}
 				return false, nil
 			}
 
 			return true, nil
 		})
-		if err != nil {
+		if err == nil {
+			continue
+		}
+
+		// A cancelled or expired build context is fatal. It is not a registry
+		// being unreachable, so do not skip it.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+
+		// Bad credentials fail the build now so the error is clear and no worker
+		// time is wasted on creds we know are wrong.
+		if errdefs.IsUnauthorized(err) {
 			//nolint:lll
 			detailedErr := fmt.Errorf("client credentials are invalid for registry %q.\nMake sure the following sources of credentials are correct: %s.\nUnderlying error: %w", server, strings.Join(helpMessage, ", "), err)
 			errs = append(errs, detailedErr)
+			continue
 		}
+
+		// A registry we cannot reach must not fail a build that does not use it.
+		// Buildkit still fails the build later if it actually needs this registry.
+		reason := err
+		if authErr != nil {
+			reason = authErr
+		}
+		logger.Info("Skipping credential check for unreachable registry", "registry", server, "reason", reason.Error())
 	}
 	if len(errs) != 0 {
 		return multierr.Combine(errs...)

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -180,7 +180,6 @@ func targetedRegistryHosts(refs []string) map[string]bool {
 // *url.Error, which satisfies net.Error whatever the cause, and docker's bearer
 // transport returns registry status errors through it. Gating on that reads a
 // bearer 401 as an outage and lets a typo'd password reach a leased worker.
-// Every registry we care about speaks bearer.
 func unreachable(err error) bool {
 	if err == nil {
 		return false
@@ -266,9 +265,9 @@ func Verify(
 		}
 
 		// A dead build context is fatal. It is not an unreachable registry, and it
-		// must not discard cred failures already found for other registries.
+		// must not discard cred failures already found, this registry's included.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return multierr.Append(multierr.Combine(errs...), err)
+			return multierr.Combine(append(errs, answered, err)...)
 		}
 
 		// A registry that never answered must not fail the build. It may be down
@@ -288,7 +287,7 @@ func Verify(
 			reason = authErr
 		}
 		//nolint:lll
-		detailedErr := fmt.Errorf("client credentials are invalid for registry %q.\nMake sure the following sources of credentials are correct: %s.\nUnderlying error: %w", host, strings.Join(helpMessage, ", "), reason)
+		detailedErr := fmt.Errorf("client credentials are invalid for registry %q.\nMake sure the following sources of credentials are correct: %s.\nUnderlying error: %w", server, strings.Join(helpMessage, ", "), reason)
 		errs = append(errs, detailedErr)
 	}
 	if len(errs) != 0 {

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -242,9 +242,17 @@ func Verify(
 
 		auth.ServerAddress = server
 
-		var authErr error
+		var authErr, answered error
 		err := wait.ExponentialBackoffWithContext(ctx, defaultBackoff, func(ctx context.Context) (bool, error) {
 			if _, _, authErr = svc.Auth(ctx, &auth, "DominoDataLab_Hephaestus/1.0"); authErr != nil {
+				// Remember the first answer we got. Only the last retry survives in
+				// authErr, so a registry that answers and then goes down would
+				// otherwise look unreachable and let the bad cred through. Docker's
+				// own HTTPS-then-HTTP attempts inside one Auth call keep only their
+				// last error, so that layer can still mask an answer.
+				if answered == nil && !unreachable(authErr) {
+					answered = authErr
+				}
 				if errdefs.IsUnauthorized(authErr) {
 					return false, authErr
 				}
@@ -267,13 +275,16 @@ func Verify(
 		// for reasons unrelated to these creds, and buildkit fails later if the
 		// build really needs it. Anything it did answer, 401 and 403 alike, is a
 		// cred problem, so fail now before any worker time is spent.
-		if unreachable(authErr) {
+		if answered == nil && unreachable(authErr) {
 			logger.Info("Skipping credential check for unreachable registry", "registry", host, "reason", authErr.Error())
 			continue
 		}
 
 		reason := err
-		if authErr != nil {
+		switch {
+		case answered != nil:
+			reason = answered
+		case authErr != nil:
 			reason = authErr
 		}
 		//nolint:lll

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,6 +174,35 @@ func usedRegistryHosts(refs []string) map[string]bool {
 	return hosts
 }
 
+// unreachable reports whether an auth attempt failed because the registry never
+// answered, rather than answering with a credential rejection.
+//
+// It deliberately does not test the error as returned. http.Client wraps every
+// failure in *url.Error, which satisfies net.Error whatever the cause, and
+// docker's bearer token transport surfaces registry status errors through it. So
+// testing the returned error reads a bearer 401 or 403 — quay.io, ECR, GCR,
+// Docker Hub and GHCR all speak bearer — as an outage, and lets a bad credential
+// through to a leased worker. Only the transport error underneath answers the
+// question, so that is what gets tested.
+func unreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// The registry named the credential as the problem, so it answered.
+	if errdefs.IsUnauthorized(err) {
+		return false
+	}
+
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+		err = urlErr.Err
+	}
+
+	_, ok := errors.AsType[net.Error](err)
+
+	return ok
+}
+
 func Verify(
 	ctx context.Context,
 	logger logr.Logger,
@@ -243,7 +273,7 @@ func Verify(
 		// still fails the build later if it truly needs this registry. Anything
 		// the registry did answer, 401 and 403 alike, is a credential problem, so
 		// fail now while the error is clear and no worker time has been spent.
-		if _, ok := errors.AsType[net.Error](authErr); ok {
+		if unreachable(authErr) {
 			logger.Info("Skipping credential check for unreachable registry", "registry", host, "reason", authErr.Error())
 			continue
 		}

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -224,8 +224,9 @@ func Verify(
 	}
 
 	targetedHosts := targetedRegistryHosts(refs)
-	if targetedHosts == nil {
-		logger.Info("Checking every credential: a build reference could not be parsed", "references", refs)
+	if len(refs) == 0 || targetedHosts == nil {
+		logger.Info("Checking every credential: no build targets to scope to, or a reference could not be parsed",
+			"references", refs)
 	}
 
 	var errs []error

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,10 +136,15 @@ func Persist(
 }
 
 // normalizeRegistryHost reduces a docker config server key or an image ref
-// domain to a plain hostname so the two can be compared. Docker Hub goes by
-// several names, so they all collapse to "docker.io".
+// domain to a plain hostname so the two can be compared. Config keys may carry
+// a scheme, a path and even userinfo; hosts are compared case-insensitively.
+// Docker Hub goes by several names, so they all collapse to "docker.io".
 func normalizeRegistryHost(server string) string {
-	host := registry.ConvertToHostname(server)
+	host := strings.ToLower(registry.ConvertToHostname(server))
+	if at := strings.LastIndex(host, "@"); at != -1 {
+		host = host[at+1:]
+	}
+
 	if host == "index.docker.io" || host == "registry-1.docker.io" {
 		host = "docker.io"
 	}
@@ -146,16 +152,19 @@ func normalizeRegistryHost(server string) string {
 	return host
 }
 
-// usedRegistryHosts returns the set of registry hostnames the build is known
-// to use, taken from the image refs it will push.
-func usedRegistryHosts(images []string) map[string]bool {
+// usedRegistryHosts returns the set of registry hostnames the build is known to
+// use, taken from the refs it pushes and the remote caches it imports. Base
+// images are not included: they live in the Dockerfile, and resolving them means
+// parsing it, so buildkit is left to fail the build if a base image cred is bad.
+//
+// A nil result means "unknown, check everything". A ref that does not parse
+// could name any registry, so narrowing the check on it would be unsound.
+func usedRegistryHosts(refs []string) map[string]bool {
 	hosts := map[string]bool{}
-	for _, image := range images {
-		named, err := reference.ParseNormalizedNamed(image)
+	for _, ref := range refs {
+		named, err := reference.ParseNormalizedNamed(ref)
 		if err != nil {
-			// Image refs are validated by the webhook. A ref that does not
-			// parse cannot match any registry, so it adds nothing here.
-			continue
+			return nil
 		}
 
 		hosts[normalizeRegistryHost(reference.Domain(named))] = true
@@ -170,7 +179,7 @@ func Verify(
 	configDir string,
 	insecureRegistries []string,
 	helpMessage []string,
-	images []string,
+	refs []string,
 ) error {
 	filename := filepath.Join(configDir, "config.json")
 	data, err := os.ReadFile(filename)
@@ -188,15 +197,20 @@ func Verify(
 		return err
 	}
 
-	usedHosts := usedRegistryHosts(images)
+	usedHosts := usedRegistryHosts(refs)
+	if usedHosts == nil {
+		logger.Info("Checking every credential: a build reference could not be parsed", "references", refs)
+	}
 
 	var errs []error
 	for server, auth := range configJSON.Auths {
-		// Only check credentials for registries this build pushes to. A cred
-		// for any other registry cannot fail the build here, no matter its
-		// state. If no images are given, check everything.
-		if len(usedHosts) > 0 && !usedHosts[normalizeRegistryHost(server)] {
-			logger.Info("Skipping credential check for registry not used by this build", "registry", server)
+		host := normalizeRegistryHost(server)
+
+		// Only check credentials for registries this build is known to use. A
+		// cred for any other registry cannot fail the build here, no matter its
+		// state. With no known hosts, check everything.
+		if len(usedHosts) > 0 && !usedHosts[host] {
+			logger.Info("Skipping credential check for registry not used by this build", "registry", host)
 			continue
 		}
 
@@ -218,27 +232,29 @@ func Verify(
 		}
 
 		// A cancelled or expired build context is fatal. It is not a registry
-		// being unreachable, so do not skip it.
+		// being unreachable, so do not skip it, and do not discard credential
+		// failures already proven for other registries.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return err
+			return multierr.Append(multierr.Combine(errs...), err)
 		}
 
-		// Bad credentials fail the build now so the error is clear and no worker
-		// time is wasted on creds we know are wrong.
-		if errdefs.IsUnauthorized(err) {
-			//nolint:lll
-			detailedErr := fmt.Errorf("client credentials are invalid for registry %q.\nMake sure the following sources of credentials are correct: %s.\nUnderlying error: %w", server, strings.Join(helpMessage, ", "), err)
-			errs = append(errs, detailedErr)
+		// A registry we could not reach at all must not fail the build: it may be
+		// down for reasons that have nothing to do with these creds, and buildkit
+		// still fails the build later if it truly needs this registry. Anything
+		// the registry did answer, 401 and 403 alike, is a credential problem, so
+		// fail now while the error is clear and no worker time has been spent.
+		if _, ok := errors.AsType[net.Error](authErr); ok {
+			logger.Info("Skipping credential check for unreachable registry", "registry", host, "reason", authErr.Error())
 			continue
 		}
 
-		// A registry we cannot reach must not fail a build that does not use it.
-		// Buildkit still fails the build later if it actually needs this registry.
 		reason := err
 		if authErr != nil {
 			reason = authErr
 		}
-		logger.Info("Skipping credential check for unreachable registry", "registry", server, "reason", reason.Error())
+		//nolint:lll
+		detailedErr := fmt.Errorf("client credentials are invalid for registry %q.\nMake sure the following sources of credentials are correct: %s.\nUnderlying error: %w", host, strings.Join(helpMessage, ", "), reason)
+		errs = append(errs, detailedErr)
 	}
 	if len(errs) != 0 {
 		return multierr.Combine(errs...)

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -136,10 +136,9 @@ func Persist(
 	return dir, helpMessage, err
 }
 
-// normalizeRegistryHost reduces a docker config server key or an image ref
-// domain to a plain hostname so the two can be compared. Config keys may carry
-// a scheme, a path and even userinfo; hosts are compared case-insensitively.
-// Docker Hub goes by several names, so they all collapse to "docker.io".
+// normalizeRegistryHost reduces a docker config server key or a ref domain to a
+// bare host so the two compare. Keys can carry a scheme, a path and userinfo.
+// Docker Hub answers to several names, so they all collapse to docker.io.
 func normalizeRegistryHost(server string) string {
 	host := strings.ToLower(registry.ConvertToHostname(server))
 	if at := strings.LastIndex(host, "@"); at != -1 {
@@ -153,14 +152,14 @@ func normalizeRegistryHost(server string) string {
 	return host
 }
 
-// usedRegistryHosts returns the set of registry hostnames the build is known to
-// use, taken from the refs it pushes and the remote caches it imports. Base
-// images are not included: they live in the Dockerfile, and resolving them means
-// parsing it, so buildkit is left to fail the build if a base image cred is bad.
+// targetedRegistryHosts returns the hosts a build pushes to or pulls cache from.
+// Narrower than "hosts the build uses": a base image pull is a use and is not
+// included, because base images live in the Dockerfile and we never parse it.
+// Buildkit authenticates those itself.
 //
-// A nil result means "unknown, check everything". A ref that does not parse
-// could name any registry, so narrowing the check on it would be unsound.
-func usedRegistryHosts(refs []string) map[string]bool {
+// nil or empty both mean "check everything": a ref we cannot parse could name
+// any host, and no refs at all tells us nothing.
+func targetedRegistryHosts(refs []string) map[string]bool {
 	hosts := map[string]bool{}
 	for _, ref := range refs {
 		named, err := reference.ParseNormalizedNamed(ref)
@@ -174,16 +173,14 @@ func usedRegistryHosts(refs []string) map[string]bool {
 	return hosts
 }
 
-// unreachable reports whether an auth attempt failed because the registry never
-// answered, rather than answering with a credential rejection.
+// unreachable reports whether the registry never answered, rather than answering
+// with a rejection.
 //
-// It deliberately does not test the error as returned. http.Client wraps every
-// failure in *url.Error, which satisfies net.Error whatever the cause, and
-// docker's bearer token transport surfaces registry status errors through it. So
-// testing the returned error reads a bearer 401 or 403 — quay.io, ECR, GCR,
-// Docker Hub and GHCR all speak bearer — as an outage, and lets a bad credential
-// through to a leased worker. Only the transport error underneath answers the
-// question, so that is what gets tested.
+// Don't test the top-level error's type. http.Client wraps every failure in
+// *url.Error, which satisfies net.Error whatever the cause, and docker's bearer
+// transport returns registry status errors through it. Gating on that reads a
+// bearer 401 as an outage and lets a typo'd password reach a leased worker.
+// Every registry we care about speaks bearer.
 func unreachable(err error) bool {
 	if err == nil {
 		return false
@@ -227,8 +224,8 @@ func Verify(
 		return err
 	}
 
-	usedHosts := usedRegistryHosts(refs)
-	if usedHosts == nil {
+	targetedHosts := targetedRegistryHosts(refs)
+	if targetedHosts == nil {
 		logger.Info("Checking every credential: a build reference could not be parsed", "references", refs)
 	}
 
@@ -236,11 +233,10 @@ func Verify(
 	for server, auth := range configJSON.Auths {
 		host := normalizeRegistryHost(server)
 
-		// Only check credentials for registries this build is known to use. A
-		// cred for any other registry cannot fail the build here, no matter its
-		// state. With no known hosts, check everything.
-		if len(usedHosts) > 0 && !usedHosts[host] {
-			logger.Info("Skipping credential check for registry not used by this build", "registry", host)
+		// A cred for any other registry cannot fail the build, whatever state it
+		// is in. Base image registries land here too.
+		if len(targetedHosts) > 0 && !targetedHosts[host] {
+			logger.Info("Skipping credential check: registry is not a build target or cache ref", "registry", host)
 			continue
 		}
 
@@ -261,18 +257,16 @@ func Verify(
 			continue
 		}
 
-		// A cancelled or expired build context is fatal. It is not a registry
-		// being unreachable, so do not skip it, and do not discard credential
-		// failures already proven for other registries.
+		// A dead build context is fatal. It is not an unreachable registry, and it
+		// must not discard cred failures already found for other registries.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return multierr.Append(multierr.Combine(errs...), err)
 		}
 
-		// A registry we could not reach at all must not fail the build: it may be
-		// down for reasons that have nothing to do with these creds, and buildkit
-		// still fails the build later if it truly needs this registry. Anything
-		// the registry did answer, 401 and 403 alike, is a credential problem, so
-		// fail now while the error is clear and no worker time has been spent.
+		// A registry that never answered must not fail the build. It may be down
+		// for reasons unrelated to these creds, and buildkit fails later if the
+		// build really needs it. Anything it did answer, 401 and 403 alike, is a
+		// cred problem, so fail now before any worker time is spent.
 		if unreachable(authErr) {
 			logger.Info("Skipping credential check for unreachable registry", "registry", host, "reason", authErr.Error())
 			continue

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -3,9 +3,13 @@ package credentials
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/registry"
 	"github.com/go-logr/logr"
@@ -13,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -70,5 +75,97 @@ func TestPersist(t *testing.T) {
 		assert.Equal(t, expected, actual)
 		assert.Equal(t, len(helpMessage), 1)
 		assert.Contains(t, helpMessage[0], "secret \"test-creds\" in namespace \"test-ns\"")
+	})
+}
+
+// writeDockerConfig writes a config.json holding one credential for the given
+// server key and returns its directory.
+func writeDockerConfig(t *testing.T, server string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	config := DockerConfigJSON{Auths: AuthConfigs{
+		server: registry.AuthConfig{Username: "u", Password: "p"},
+	}}
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), data, 0644))
+
+	return dir
+}
+
+// unreachableHost returns a host:port that refuses connections, by closing a
+// listener and reusing its address.
+func unreachableHost(t *testing.T) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// cancelledContext returns an already cancelled context. Verify aborts before
+// contacting a registry it checks, so tests use it to observe whether a
+// credential was checked (context.Canceled) or skipped (nil).
+func cancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	return ctx
+}
+
+func TestVerify(t *testing.T) {
+	t.Run("unreachable_registry_is_skipped", func(t *testing.T) {
+		// A refused connection is not an unauthorized error, so Verify must
+		// skip the registry and let the build continue instead of failing it.
+		host := unreachableHost(t)
+		dir := writeDockerConfig(t, host)
+
+		// Keep the test quick: one attempt, no long backoff.
+		orig := defaultBackoff
+		defaultBackoff = wait.Backoff{Duration: time.Millisecond, Steps: 1}
+		t.Cleanup(func() { defaultBackoff = orig })
+
+		err := Verify(context.Background(), logr.Discard(), dir, nil, []string{"test"}, []string{host + "/org/app:latest"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("cancelled_context_is_fatal", func(t *testing.T) {
+		// A cancelled build context must fail the build, not be mistaken for an
+		// unreachable registry and skipped.
+		host := unreachableHost(t)
+		dir := writeDockerConfig(t, host)
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{host + "/org/app:latest"})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("unused_registry_is_not_checked", func(t *testing.T) {
+		// The build pushes to another registry, so this credential must be
+		// skipped before any check. With a cancelled context a check would
+		// return context.Canceled, so nil proves no check happened.
+		dir := writeDockerConfig(t, "unused.example.com")
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"used.example.com/org/app:latest"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("docker_hub_alias_matches", func(t *testing.T) {
+		// A legacy Docker Hub server key must match an image ref that
+		// normalizes to docker.io, so this credential is checked.
+		dir := writeDockerConfig(t, "https://index.docker.io/v1/")
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"org/app:latest"})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("no_images_checks_all", func(t *testing.T) {
+		// Without an image list Verify falls back to checking every
+		// credential, so the check runs and reports the cancelled context.
+		dir := writeDockerConfig(t, "unused.example.com")
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, nil)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -112,7 +112,9 @@ func respondingHost(t *testing.T, status int) string {
 
 // bearerHost answers a token request with the given status after a Bearer
 // challenge. Bearer rejections arrive wrapped in *url.Error, which Basic ones do
-// not, so it needs its own coverage.
+// not, so it needs its own coverage. The JSON content type matters: without it
+// docker parses the body as a single errcode.Error and a 401 becomes
+// unauthorizedErr, a shape real registries never send.
 func bearerHost(t *testing.T, status int) string {
 	t.Helper()
 
@@ -121,6 +123,7 @@ func bearerHost(t *testing.T, status int) string {
 	t.Cleanup(srv.Close)
 
 	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(`{"errors":[{"code":"UNAUTHORIZED","message":"bad creds"}]}`))
 	})
@@ -153,6 +156,7 @@ func rejectThenDieHost(t *testing.T, authed *atomic.Int32) string {
 		w.WriteHeader(http.StatusForbidden)
 		once.Do(func() { go srv.Close() })
 	}))
+	t.Cleanup(srv.Close)
 
 	return strings.TrimPrefix(srv.URL, "http://")
 }
@@ -348,10 +352,13 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("port_is_part_of_the_host", func(t *testing.T) {
-		// A non-default port is a distinct host.
+		// A non-default port is a distinct host: same port matches, no port does not.
 		dir := writeDockerConfigFor(t, "myreg.example.com:5000")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com:5000/org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)
+
+		err = Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com/org/app:latest"})
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -130,6 +132,31 @@ func bearerHost(t *testing.T, status int) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
 
+// rejectThenDieHost 403s authenticated requests, then stops answering. Only the
+// last attempt survives in authErr, so this is the shape that hides a bad cred
+// behind a later outage. The counter lets the test prove the outage happened: if
+// the listener never died, the run proves nothing.
+func rejectThenDieHost(t *testing.T, authed *atomic.Int32) string {
+	t.Helper()
+
+	var srv *httptest.Server
+	var once sync.Once
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		authed.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+		once.Do(func() { go srv.Close() })
+	}))
+
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
 // writeDockerConfigFor writes a config.json with one cred per server.
 func writeDockerConfigFor(t *testing.T, servers ...string) string {
 	t.Helper()
@@ -233,6 +260,25 @@ func TestVerify(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), bad)
 		assert.NotContains(t, err.Error(), down)
+	})
+
+	t.Run("rejection_is_not_erased_by_a_later_outage", func(t *testing.T) {
+		// The registry rejected the cred, then went down. The build must still
+		// fail: the outage arrived second and does not clear the rejection.
+		var authed atomic.Int32
+		host := rejectThenDieHost(t, &authed)
+		dir := writeDockerConfigFor(t, host)
+
+		orig := defaultBackoff
+		defaultBackoff = wait.Backoff{Duration: 300 * time.Millisecond, Steps: 3}
+		t.Cleanup(func() { defaultBackoff = orig })
+
+		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client credentials are invalid")
+		// Without this the run could be three 403s, which passes either way and
+		// would quietly stop being a regression test.
+		require.Equal(t, int32(1), authed.Load(), "registry answered more than once, so no outage followed the rejection")
 	})
 
 	t.Run("cancelled_context_is_fatal", func(t *testing.T) {

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -125,6 +126,46 @@ func respondingHost(t *testing.T, status int) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
 
+// bearerHost starts a registry that answers a token request with the given
+// status after a Bearer challenge, and returns its host:port. Bearer is the flow
+// quay.io, ECR, GCR, Docker Hub and GHCR all use, and it reports a rejected
+// credential through a *url.Error, so it must be covered separately from Basic.
+func bearerHost(t *testing.T, status int) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"errors":[{"code":"UNAUTHORIZED","message":"bad creds"}]}`))
+	})
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s/token",service="registry"`, srv.URL))
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// writeDockerConfigFor writes a config.json holding one credential per server.
+func writeDockerConfigFor(t *testing.T, servers ...string) string {
+	t.Helper()
+
+	auths := AuthConfigs{}
+	for _, server := range servers {
+		auths[server] = registry.AuthConfig{Username: "u", Password: "p"}
+	}
+
+	dir := t.TempDir()
+	data, err := json.Marshal(DockerConfigJSON{Auths: auths})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), data, 0644))
+
+	return dir
+}
+
 // cancelledContext returns an already cancelled context. Verify aborts before
 // contacting a registry it checks, so tests use it to observe whether a
 // credential was checked (context.Canceled) or skipped (nil).
@@ -179,6 +220,47 @@ func TestVerify(t *testing.T) {
 		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "client credentials are invalid")
+	})
+
+	t.Run("bearer_unauthorized_registry_is_fatal", func(t *testing.T) {
+		// The registries that matter all speak bearer, and a rejected token comes
+		// back wrapped in a *url.Error, which satisfies net.Error. Testing the
+		// returned error would read this as an outage and let a bad credential
+		// reach a leased worker, so it must be fatal here.
+		host := bearerHost(t, http.StatusUnauthorized)
+		dir := writeDockerConfig(t, host)
+		shortBackoff(t)
+
+		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client credentials are invalid")
+	})
+
+	t.Run("bearer_forbidden_registry_is_fatal", func(t *testing.T) {
+		// Same as above for a token endpoint that denies rather than rejects: the
+		// registry answered, so the credential is the problem.
+		host := bearerHost(t, http.StatusForbidden)
+		dir := writeDockerConfig(t, host)
+		shortBackoff(t)
+
+		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client credentials are invalid")
+	})
+
+	t.Run("skipped_registry_does_not_hide_a_bad_credential", func(t *testing.T) {
+		// Skipping one unreachable registry must not discard the credential
+		// failure proven for another registry in the same build.
+		down := unreachableHost(t)
+		bad := respondingHost(t, http.StatusUnauthorized)
+		dir := writeDockerConfigFor(t, down, bad)
+		shortBackoff(t)
+
+		//nolint:lll
+		err := Verify(context.Background(), logr.Discard(), dir, []string{bad}, []string{"test"}, []string{down + "/org/app:latest", bad + "/org/app:latest"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), bad)
+		assert.NotContains(t, err.Error(), down)
 	})
 
 	t.Run("cancelled_context_is_fatal", func(t *testing.T) {

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -79,24 +79,7 @@ func TestPersist(t *testing.T) {
 	})
 }
 
-// writeDockerConfig writes a config.json holding one credential for the given
-// server key and returns its directory.
-func writeDockerConfig(t *testing.T, server string) string {
-	t.Helper()
-
-	dir := t.TempDir()
-	config := DockerConfigJSON{Auths: AuthConfigs{
-		server: registry.AuthConfig{Username: "u", Password: "p"},
-	}}
-	data, err := json.Marshal(config)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), data, 0644))
-
-	return dir
-}
-
-// unreachableHost returns a host:port that refuses connections, by closing a
-// listener and reusing its address.
+// unreachableHost returns a host:port that refuses connections.
 func unreachableHost(t *testing.T) string {
 	t.Helper()
 
@@ -106,8 +89,7 @@ func unreachableHost(t *testing.T) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
 
-// respondingHost starts a registry that answers every request with the given
-// status after a basic-auth challenge, and returns its host:port.
+// respondingHost answers with the given status after a Basic challenge.
 func respondingHost(t *testing.T, status int) string {
 	t.Helper()
 
@@ -126,10 +108,9 @@ func respondingHost(t *testing.T, status int) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
 
-// bearerHost starts a registry that answers a token request with the given
-// status after a Bearer challenge, and returns its host:port. Bearer is the flow
-// quay.io, ECR, GCR, Docker Hub and GHCR all use, and it reports a rejected
-// credential through a *url.Error, so it must be covered separately from Basic.
+// bearerHost answers a token request with the given status after a Bearer
+// challenge. Bearer rejections arrive wrapped in *url.Error, which Basic ones do
+// not, so it needs its own coverage.
 func bearerHost(t *testing.T, status int) string {
 	t.Helper()
 
@@ -149,7 +130,7 @@ func bearerHost(t *testing.T, status int) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
 
-// writeDockerConfigFor writes a config.json holding one credential per server.
+// writeDockerConfigFor writes a config.json with one cred per server.
 func writeDockerConfigFor(t *testing.T, servers ...string) string {
 	t.Helper()
 
@@ -166,9 +147,8 @@ func writeDockerConfigFor(t *testing.T, servers ...string) string {
 	return dir
 }
 
-// cancelledContext returns an already cancelled context. Verify aborts before
-// contacting a registry it checks, so tests use it to observe whether a
-// credential was checked (context.Canceled) or skipped (nil).
+// cancelledContext returns a cancelled context. Verify aborts before contacting a
+// registry it checks, so context.Canceled means checked and nil means skipped.
 func cancelledContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -176,8 +156,7 @@ func cancelledContext() context.Context {
 	return ctx
 }
 
-// shortBackoff makes Verify try once with no real wait, so tests that let it
-// contact a registry stay fast.
+// shortBackoff makes Verify try once with no wait.
 func shortBackoff(t *testing.T) {
 	t.Helper()
 
@@ -188,10 +167,9 @@ func shortBackoff(t *testing.T) {
 
 func TestVerify(t *testing.T) {
 	t.Run("unreachable_registry_is_skipped", func(t *testing.T) {
-		// A refused connection is not an unauthorized error, so Verify must
-		// skip the registry and let the build continue instead of failing it.
+		// Refused connection, so skip and let the build run.
 		host := unreachableHost(t)
-		dir := writeDockerConfig(t, host)
+		dir := writeDockerConfigFor(t, host)
 		shortBackoff(t)
 
 		err := Verify(context.Background(), logr.Discard(), dir, nil, []string{"test"}, []string{host + "/org/app:latest"})
@@ -199,10 +177,9 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("unauthorized_registry_is_fatal", func(t *testing.T) {
-		// The registry answered, so this is a credential problem and not an
-		// outage. It must fail the build before a worker is leased.
+		// It answered, so the cred is wrong. Fail before leasing a worker.
 		host := respondingHost(t, http.StatusUnauthorized)
-		dir := writeDockerConfig(t, host)
+		dir := writeDockerConfigFor(t, host)
 		shortBackoff(t)
 
 		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
@@ -211,10 +188,9 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("forbidden_registry_is_fatal", func(t *testing.T) {
-		// A 403 is not an outage either: the account exists but cannot use this
-		// registry. Only errors with no response at all are skipped.
+		// Not an outage either. Only no-response gets skipped.
 		host := respondingHost(t, http.StatusForbidden)
-		dir := writeDockerConfig(t, host)
+		dir := writeDockerConfigFor(t, host)
 		shortBackoff(t)
 
 		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
@@ -223,12 +199,10 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("bearer_unauthorized_registry_is_fatal", func(t *testing.T) {
-		// The registries that matter all speak bearer, and a rejected token comes
-		// back wrapped in a *url.Error, which satisfies net.Error. Testing the
-		// returned error would read this as an outage and let a bad credential
-		// reach a leased worker, so it must be fatal here.
+		// The bearer 401 arrives inside a *url.Error, which satisfies net.Error.
+		// Reading that as an outage is the bug this guards.
 		host := bearerHost(t, http.StatusUnauthorized)
-		dir := writeDockerConfig(t, host)
+		dir := writeDockerConfigFor(t, host)
 		shortBackoff(t)
 
 		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
@@ -237,10 +211,9 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("bearer_forbidden_registry_is_fatal", func(t *testing.T) {
-		// Same as above for a token endpoint that denies rather than rejects: the
-		// registry answered, so the credential is the problem.
+		// Same for 403. It still answered.
 		host := bearerHost(t, http.StatusForbidden)
-		dir := writeDockerConfig(t, host)
+		dir := writeDockerConfigFor(t, host)
 		shortBackoff(t)
 
 		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
@@ -249,8 +222,7 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("skipped_registry_does_not_hide_a_bad_credential", func(t *testing.T) {
-		// Skipping one unreachable registry must not discard the credential
-		// failure proven for another registry in the same build.
+		// Skipping one registry must not bury another's cred failure.
 		down := unreachableHost(t)
 		bad := respondingHost(t, http.StatusUnauthorized)
 		dir := writeDockerConfigFor(t, down, bad)
@@ -264,65 +236,57 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("cancelled_context_is_fatal", func(t *testing.T) {
-		// A cancelled build context must fail the build, not be mistaken for an
-		// unreachable registry and skipped.
+		// A cancelled context is not an unreachable registry.
 		host := unreachableHost(t)
-		dir := writeDockerConfig(t, host)
+		dir := writeDockerConfigFor(t, host)
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{host + "/org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
-	t.Run("unused_registry_is_not_checked", func(t *testing.T) {
-		// The build pushes to another registry, so this credential must be
-		// skipped before any check. With a cancelled context a check would
-		// return context.Canceled, so nil proves no check happened.
-		dir := writeDockerConfig(t, "unused.example.com")
+	t.Run("non_target_registry_is_not_checked", func(t *testing.T) {
+		// Not a target, so never checked. nil proves it, since a check would
+		// return context.Canceled.
+		dir := writeDockerConfigFor(t, "unused.example.com")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"used.example.com/org/app:latest"})
 		assert.NoError(t, err)
 	})
 
 	t.Run("docker_hub_alias_matches", func(t *testing.T) {
-		// A legacy Docker Hub server key must match an image ref that
-		// normalizes to docker.io, so this credential is checked.
-		dir := writeDockerConfig(t, "https://index.docker.io/v1/")
+		// Legacy hub key must match a ref that normalizes to docker.io.
+		dir := writeDockerConfigFor(t, "https://index.docker.io/v1/")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("no_refs_checks_all", func(t *testing.T) {
-		// Without a reference list Verify falls back to checking every
-		// credential, so the check runs and reports the cancelled context.
-		dir := writeDockerConfig(t, "unused.example.com")
+		dir := writeDockerConfigFor(t, "unused.example.com")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, nil)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("host_case_is_ignored", func(t *testing.T) {
-		// A server key and an image ref that differ only in case name the same
-		// registry, so the credential must still be checked.
-		dir := writeDockerConfig(t, "MyReg.Example.com")
+		// Case-only difference is the same registry.
+		dir := writeDockerConfigFor(t, "MyReg.Example.com")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com/org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("server_key_userinfo_is_stripped", func(t *testing.T) {
-		// Credentials embedded in a server key must not stop it matching the
-		// registry it names.
-		dir := writeDockerConfig(t, "https://alice:s3cr3t@myreg.example.com/v1/")
+		// Creds embedded in a key must not stop it matching.
+		dir := writeDockerConfigFor(t, "https://alice:s3cr3t@myreg.example.com/v1/")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com/org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("cache_import_registry_is_checked", func(t *testing.T) {
-		// Remote build caches are pulled with these credentials, so a cache-only
-		// registry counts as used.
-		dir := writeDockerConfig(t, "cache.example.com")
+		// Cache imports are pulls, so a cache-only registry is still checked.
+		dir := writeDockerConfigFor(t, "cache.example.com")
 
 		//nolint:lll
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"push.example.com/org/app:latest", "cache.example.com/org/app-cache:latest"})
@@ -330,9 +294,7 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("unparseable_ref_checks_all", func(t *testing.T) {
-		// A reference we cannot resolve to a host could name any registry, so
-		// narrowing the check would be unsound: check everything instead.
-		dir := writeDockerConfig(t, "unused.example.com")
+		dir := writeDockerConfigFor(t, "unused.example.com")
 		badRef := "aaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999"
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{badRef})
@@ -340,9 +302,8 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("port_is_part_of_the_host", func(t *testing.T) {
-		// A registry on a non-default port is a distinct host, matched with its
-		// port on both sides.
-		dir := writeDockerConfig(t, "myreg.example.com:5000")
+		// A non-default port is a distinct host.
+		dir := writeDockerConfigFor(t, "myreg.example.com:5000")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com:5000/org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -105,6 +105,26 @@ func unreachableHost(t *testing.T) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
 
+// respondingHost starts a registry that answers every request with the given
+// status after a basic-auth challenge, and returns its host:port.
+func respondingHost(t *testing.T, status int) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
 // cancelledContext returns an already cancelled context. Verify aborts before
 // contacting a registry it checks, so tests use it to observe whether a
 // credential was checked (context.Canceled) or skipped (nil).
@@ -115,20 +135,50 @@ func cancelledContext() context.Context {
 	return ctx
 }
 
+// shortBackoff makes Verify try once with no real wait, so tests that let it
+// contact a registry stay fast.
+func shortBackoff(t *testing.T) {
+	t.Helper()
+
+	orig := defaultBackoff
+	defaultBackoff = wait.Backoff{Duration: time.Millisecond, Steps: 1}
+	t.Cleanup(func() { defaultBackoff = orig })
+}
+
 func TestVerify(t *testing.T) {
 	t.Run("unreachable_registry_is_skipped", func(t *testing.T) {
 		// A refused connection is not an unauthorized error, so Verify must
 		// skip the registry and let the build continue instead of failing it.
 		host := unreachableHost(t)
 		dir := writeDockerConfig(t, host)
-
-		// Keep the test quick: one attempt, no long backoff.
-		orig := defaultBackoff
-		defaultBackoff = wait.Backoff{Duration: time.Millisecond, Steps: 1}
-		t.Cleanup(func() { defaultBackoff = orig })
+		shortBackoff(t)
 
 		err := Verify(context.Background(), logr.Discard(), dir, nil, []string{"test"}, []string{host + "/org/app:latest"})
 		assert.NoError(t, err)
+	})
+
+	t.Run("unauthorized_registry_is_fatal", func(t *testing.T) {
+		// The registry answered, so this is a credential problem and not an
+		// outage. It must fail the build before a worker is leased.
+		host := respondingHost(t, http.StatusUnauthorized)
+		dir := writeDockerConfig(t, host)
+		shortBackoff(t)
+
+		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client credentials are invalid")
+	})
+
+	t.Run("forbidden_registry_is_fatal", func(t *testing.T) {
+		// A 403 is not an outage either: the account exists but cannot use this
+		// registry. Only errors with no response at all are skipped.
+		host := respondingHost(t, http.StatusForbidden)
+		dir := writeDockerConfig(t, host)
+		shortBackoff(t)
+
+		err := Verify(context.Background(), logr.Discard(), dir, []string{host}, []string{"test"}, []string{host + "/org/app:latest"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client credentials are invalid")
 	})
 
 	t.Run("cancelled_context_is_fatal", func(t *testing.T) {
@@ -160,12 +210,59 @@ func TestVerify(t *testing.T) {
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
-	t.Run("no_images_checks_all", func(t *testing.T) {
-		// Without an image list Verify falls back to checking every
+	t.Run("no_refs_checks_all", func(t *testing.T) {
+		// Without a reference list Verify falls back to checking every
 		// credential, so the check runs and reports the cancelled context.
 		dir := writeDockerConfig(t, "unused.example.com")
 
 		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, nil)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("host_case_is_ignored", func(t *testing.T) {
+		// A server key and an image ref that differ only in case name the same
+		// registry, so the credential must still be checked.
+		dir := writeDockerConfig(t, "MyReg.Example.com")
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com/org/app:latest"})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("server_key_userinfo_is_stripped", func(t *testing.T) {
+		// Credentials embedded in a server key must not stop it matching the
+		// registry it names.
+		dir := writeDockerConfig(t, "https://alice:s3cr3t@myreg.example.com/v1/")
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com/org/app:latest"})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("cache_import_registry_is_checked", func(t *testing.T) {
+		// Remote build caches are pulled with these credentials, so a cache-only
+		// registry counts as used.
+		dir := writeDockerConfig(t, "cache.example.com")
+
+		//nolint:lll
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"push.example.com/org/app:latest", "cache.example.com/org/app-cache:latest"})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("unparseable_ref_checks_all", func(t *testing.T) {
+		// A reference we cannot resolve to a host could name any registry, so
+		// narrowing the check would be unsound: check everything instead.
+		dir := writeDockerConfig(t, "unused.example.com")
+		badRef := "aaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999"
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{badRef})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("port_is_part_of_the_host", func(t *testing.T) {
+		// A registry on a non-default port is a distinct host, matched with its
+		// port on both sides.
+		dir := writeDockerConfig(t, "myreg.example.com:5000")
+
+		err := Verify(cancelledContext(), logr.Discard(), dir, nil, []string{"test"}, []string{"myreg.example.com:5000/org/app:latest"})
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 }


### PR DESCRIPTION
Jira: https://dominodatalab.atlassian.net/browse/DOM-78638

Reference: https://dominodatalab.atlassian.net/browse/OT-3690

## Problem
Before a build starts, Hephaestus checks credentials for every configured registry, and one failed check fails the build. During the quay.io outage (OT-3690) that took down Cloud builds that never touch quay.io. The creds were valid. quay.io was unreachable, and the retry burned 31 seconds before failing the build.

## Change
`credentials.Verify` follows two rules:

1. Only creds for the registries a build **targets or uses for caching** are checked: the registries in `spec.images` and `spec.importRemoteBuildCache`, the refs Hephaestus has in hand. A base image pull is a use and is not covered. Base images live in the Dockerfile, resolving them means parsing it, and buildkit authenticates those itself. If a ref cannot be parsed the registry is unknown, so every cred is checked.
2. A checked registry that never answered is skipped with a warning. Anything it did answer with (401, 403, 5xx) is a credential problem and fails the build before a worker is leased. The first answer sticks: a registry that rejects the cred and then goes down mid retry still fails the build. A cancelled build context stays fatal and keeps the credential failures already found.

```
                     ┌──────────────────────────────────────────────────────────┐
                     │  ImageBuild dispatched with creds for:                   │
                     │  quay.io · ECR · docker.io      build pushes to ECR only │
                     └──────────────────────────────────────────────────────────┘

  BEFORE                                      AFTER
  ══════                                      ═════
  validate ALL configured registries         validate ONLY target + cache registries
        │                                           │
        ├─ quay.io outage                           ├─ quay.io outage ..... not checked
        │    retry ~31s                             ├─ quay.io bad cred ... not checked
        │    ✖ BUILD FAILS                          │
        │                                           ├─ ECR bad cred ....... ✖ fail fast (kept)
        ├─ quay.io bad cred                         ├─ ECR 403 ............ ✖ fail fast (kept)
        │    ✖ BUILD FAILS                          ├─ ECR unreachable .... warn + continue
        │                                           │     buildkit fails the push
        ▼                                           ▼     itself if ECR stays down
   build never starts                          build runs
```

| Scenario | Before | After |
|---|---|---|
| Unused registry down **([OT-3690](https://dominodatalab.atlassian.net/browse/OT-3690))** | build fails after a 31 second retry | ignored, build runs |
| Unused registry bad cred | build fails | ignored, build runs |
| Base image registry bad cred | build fails at validation, clear message | build fails at pull with buildkit's error, after a worker is leased |
| Target or cache registry bad cred | build fails fast | build fails fast (unchanged) |
| Target or cache registry returns 403 | build fails | build fails (unchanged) |
| Target or cache registry rejects the cred, then goes down | build fails | build fails (unchanged) |
| Target or cache registry never answers | build fails after retry | warning logged, buildkit surfaces the real push error |
| Build context cancelled | build fails | build fails (unchanged) |

Only a registry that did not respond at all is skipped. A bad cred is a bad cred whatever status it comes back with, and `errdefs.IsUnauthorized` cannot be the gate: docker only produces it for a 401 body with no JSON content type, which real registries never send, so a bearer 401 from quay.io arrives as a plain `*url.Error` like any transport failure. Gating on it would let a wrong password through to a leased worker.

## Test
`TestVerify`, 16 subtests: unreachable registry is skipped, Basic and Bearer 401 and 403 are fatal, a skipped registry does not hide a bad cred elsewhere, a rejection followed by an outage still fails, cancelled context is fatal, unused registry is never contacted, cache import registry is checked, legacy Docker Hub keys match hub images, host case and URL userinfo in a server key are normalised away, ports are part of the host in both directions, an unparseable ref checks everything, an empty ref list checks everything.

Verified on cluster `mhhepha138692`, twice: unused registry with a bad cred builds, bad bearer cred fails before a worker is leased, unreachable target registry is skipped and buildkit reports the push failure. Logs and manifests in the [evidence comment](https://github.com/dominodatalab/hephaestus/pull/420#issuecomment-5283034914).
