### PR TITLE
VUL-1647: bump Go toolchain to 1.26.5 for CVE-2026-39822

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dominodatalab/hephaestus
 
 go 1.26.3
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 // NOTE: local development
 // replace github.com/dominodatalab/controller-util => ../controller-util


### PR DESCRIPTION
Jira: https://dominodatalab.atlassian.net/browse/VUL-1647

Bumps the go.mod toolchain directive from go1.26.4 to go1.26.5 to patch **CVE-2026-39822** (Go stdlib), which is compiled into `/usr/bin/hephaestus-controller`. The shipped 0.12.15 binary embeds `stdlib v1.26.4`; go1.26.5 is the first patched release for this line.

Verification: built the image from this branch (`golang:1.26-alpine` now serves go1.26.5) and scanned with grype+trivy — CVE-2026-39822 no longer present; the built binary embeds `go1.26.5`.

Not fixed here: **CVE-2026-34040** (`github.com/docker/docker` v28.5.2, fixed only in v29.3.1) requires a major-version bump (28 to 29), which Renovate disables and which is high-risk for this buildkit controller. Left for a separate operator-reviewed change.