### PR TITLE
DOM-78772 fix: set oci-mediatypes=false for gzip/zstd image exports

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -152,9 +152,11 @@ func validateCompression(compression string, name string) map[string]string {
 		attrs["compression"] = "zstd"
 		attrs["force-compression"] = truth
 		attrs["push"] = truth
+		attrs["oci-mediatypes"] = "false"
 	// default is gzip
 	default:
 		attrs["push"] = truth
+		attrs["oci-mediatypes"] = "false"
 	}
 	return attrs
 }


### PR DESCRIPTION
## Problem

BuildKit v0.31.0 changed the default manifest format for the `image` exporter to OCI (`application/vnd.oci.image.manifest.v1+json`). Previously the default was Docker Image Manifest v2 Schema 2 (`application/vnd.docker.distribution.manifest.v2+json`). This broke any downstream registry consumer that requires Docker v2 format.

From the [v0.31.0 release notes](https://github.com/moby/buildkit/releases/tag/v0.31.0) ([#6824](https://github.com/moby/buildkit/pull/6824)):

> All image results now default to using OCI media types. Previously this was applied based on whether annotations or attestations were needed. `oci-mediatypes=false` can be used for legacy Docker media types.

## Fix

In `pkg/buildkit/buildkit.go`, `validateCompression` builds the attrs map for the buildkit `ExporterImage` solve. The `estargz` case already sets `oci-mediatypes=true` (required — estargz layers use an OCI-specific media type). The `zstd` and default (gzip) cases had no explicit value, so after the v0.31.0 upgrade they silently started producing OCI manifests.

This PR sets `oci-mediatypes=false` for `zstd` and `gzip` (default), restoring the Docker v2 manifest format that was implicit before v0.31.0. The `estargz` case is unchanged.