### PR TITLE
VUL-1647: add Renovate automerge rule for Dockerfile digest/patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,15 @@
       "description": "Group the Go version bump (go.mod toolchain directive, Dockerfile base image, CI GO_VERSION) into one PR",
       "groupName": "go version",
       "matchDepNames": ["go", "golang"]
+    },
+    {
+      "description": "Automerge digest and patch updates for Dockerfile bases",
+      "matchUpdateTypes": ["digest", "patch"],
+      "matchManagers": ["dockerfile"],
+      "schedule": ["at any time"],
+      "automerge": true,
+      "platformAutomerge": true,
+      "automergeType": "branch"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Jira: https://dominodatalab.atlassian.net/browse/VUL-1647

Adds a Renovate automerge rule for Dockerfile base image digest and patch updates. No cgr.dev base in this repo, so the rule is unscoped (covers golang:alpine and gcr.io/distroless bases).

Gap identified by duty (g) hygiene audit: no packageRule automerges digest/patch updates, meaning Dockerfile base bump PRs from Renovate sat waiting for manual merge. With automerge and platformAutomerge enabled, future digest re-pins will land without human intervention.

Renovation config validated: JSON parse clean.