### PR TITLE
Use Quay robot federation with GHA OIDC token

### DIFF
--- a/.github/actions/quay-robot-login/action.yml
+++ b/.github/actions/quay-robot-login/action.yml
@@ -1,0 +1,33 @@
+name: Quay Robot Federation Login
+description: Exchanges a GitHub Actions OIDC token for a short-lived Quay.io robot account token and logs in
+inputs:
+  username:
+    required: true
+    description: Quay robot account username (e.g. org+robotname)
+runs:
+  using: composite
+  steps:
+    - name: Exchange OIDC token for Quay robot token
+      id: quay
+      shell: bash
+      run: |
+        oidc_token=$(curl -sSf -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=quay.io" | jq -r .value)
+        echo "::add-mask::${oidc_token}"
+
+        response=$(curl -sSf -u "${{ inputs.username }}:${oidc_token}" \
+          "https://quay.io/oauth2/federation/robot/token")
+        quay_token=$(echo "${response}" | jq -r .token)
+        echo "::add-mask::${quay_token}"
+
+        ttl=$(echo "${response}" | jq -r '.expires_in // .expiration // empty')
+        echo "Quay robot token TTL: ${ttl:-not reported by response}"
+
+        echo "token=${quay_token}" >> "$GITHUB_OUTPUT"
+
+    - name: Log in to Quay.io
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ inputs.username }}
+        password: ${{ steps.quay.outputs.token }}

--- a/.github/actions/quay-robot-login/action.yml
+++ b/.github/actions/quay-robot-login/action.yml
@@ -19,10 +19,6 @@ runs:
           "https://quay.io/oauth2/federation/robot/token")
         quay_token=$(echo "${response}" | jq -r .token)
         echo "::add-mask::${quay_token}"
-
-        ttl=$(echo "${response}" | jq -r '.expires_in // .expiration // empty')
-        echo "Quay robot token TTL: ${ttl:-not reported by response}"
-
         echo "token=${quay_token}" >> "$GITHUB_OUTPUT"
 
     - name: Log in to Quay.io

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
   docker-build:
     runs-on: ${{ matrix.runner }}
     needs: build
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -84,11 +87,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: ./.github/actions/quay-robot-login
         with:
-          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract Docker metadata
         id: meta
@@ -127,6 +128,9 @@ jobs:
   docker-manifest:
     runs-on: ubuntu-latest
     needs: docker-build
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       version: ${{ steps.meta.outputs.version }}
     strategy:
@@ -136,6 +140,9 @@ jobs:
           - suffix: "-debug"
           - suffix: ""
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -144,11 +151,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: ./.github/actions/quay-robot-login
         with:
-          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract Docker metadata
         id: meta

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
     needs: build
     permissions:
       contents: read
+      packages: write
       id-token: write
     strategy:
       fail-fast: false
@@ -130,6 +131,7 @@ jobs:
     needs: docker-build
     permissions:
       contents: read
+      packages: write
       id-token: write
     outputs:
       version: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -18,6 +18,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
+      packages: read
       id-token: write
     steps:
       - name: Checkout code

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -16,6 +16,9 @@ jobs:
     name: Verify Multi-arch Images
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,11 +41,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: ./.github/actions/quay-robot-login
         with:
-          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Verify multi-arch manifests
         run: |


### PR DESCRIPTION
Quay.io supports exchanging an OIDC token for a robot account token: https://docs.redhat.com/en/documentation/red_hat_quay/3/html/manage_red_hat_quay/keyless-authentication-robot-accounts#exchanging-oauth2-robot-account-token. We will exchange the OIDC token per GitHub Action run, so the Quay robot account's password is not long-lived.