### PR TITLE
DOM-78638: fail fast on a bad registry cert instead of burning the retry backoff

### DIFF
--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -199,6 +200,18 @@ func unreachable(err error) bool {
 	return ok
 }
 
+// certRejected reports whether the TLS handshake failed certificate
+// verification (unknown authority, expired, wrong host). That happens
+// client-side before any HTTP round trip, so it never satisfies
+// errdefs.IsUnauthorized, but it is exactly as final as a 401: retrying an
+// untrusted cert cannot succeed, so it must short-circuit the backoff the
+// same way a real rejection does instead of being read as an outage.
+func certRejected(err error) bool {
+	_, ok := errors.AsType[*tls.CertificateVerificationError](err)
+
+	return ok
+}
+
 func Verify(
 	ctx context.Context,
 	logger logr.Logger,
@@ -253,7 +266,7 @@ func Verify(
 				if answered == nil && !unreachable(authErr) {
 					answered = authErr
 				}
-				if errdefs.IsUnauthorized(authErr) {
+				if errdefs.IsUnauthorized(authErr) || certRejected(authErr) {
 					return false, authErr
 				}
 				return false, nil

--- a/pkg/controller/support/credentials/credentials.go
+++ b/pkg/controller/support/credentials/credentials.go
@@ -200,12 +200,9 @@ func unreachable(err error) bool {
 	return ok
 }
 
-// certRejected reports whether the TLS handshake failed certificate
-// verification (unknown authority, expired, wrong host). That happens
-// client-side before any HTTP round trip, so it never satisfies
-// errdefs.IsUnauthorized, but it is exactly as final as a 401: retrying an
-// untrusted cert cannot succeed, so it must short-circuit the backoff the
-// same way a real rejection does instead of being read as an outage.
+// certRejected reports a TLS handshake that failed certificate verification.
+// As final as a 401: never satisfies errdefs.IsUnauthorized, but retrying an
+// untrusted cert can't succeed either.
 func certRejected(err error) bool {
 	_, ok := errors.AsType[*tls.CertificateVerificationError](err)
 

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -362,3 +362,20 @@ func TestVerify(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestCertRejected(t *testing.T) {
+	// registry.NewService treats 127.0.0.0/8 as insecure by default and skips
+	// certificate verification there, so a bad cert on a local listener can
+	// never reach svc.Auth through Verify(). Exercise the real error shape
+	// http.Client produces directly instead.
+	t.Run("untrusted_cert_is_rejected_not_unreachable", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		t.Cleanup(srv.Close)
+
+		_, err := (&http.Client{Timeout: time.Second}).Get(srv.URL)
+		require.Error(t, err)
+
+		assert.True(t, certRejected(err))
+		assert.False(t, unreachable(err), "a cert failure answered; it must not be skipped as an outage")
+	})
+}

--- a/pkg/controller/support/credentials/credentials_test.go
+++ b/pkg/controller/support/credentials/credentials_test.go
@@ -364,10 +364,8 @@ func TestVerify(t *testing.T) {
 }
 
 func TestCertRejected(t *testing.T) {
-	// registry.NewService treats 127.0.0.0/8 as insecure by default and skips
-	// certificate verification there, so a bad cert on a local listener can
-	// never reach svc.Auth through Verify(). Exercise the real error shape
-	// http.Client produces directly instead.
+	// Loopback is always insecure to registry.NewService, so cert verification
+	// never runs through Verify(). Hit http.Client directly instead.
 	t.Run("untrusted_cert_is_rejected_not_unreachable", func(t *testing.T) {
 		srv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 		t.Cleanup(srv.Close)


### PR DESCRIPTION
Jira: https://dominodatalab.atlassian.net/browse/DOM-78638

Follow-up to #420: dclegg's review comment on that PR landed after merge and was never addressed.

## Problem
A registry with a bad cert (unknown authority, expired, wrong host) unwraps to `*tls.CertificateVerificationError`, which matches neither `errdefs.IsUnauthorized` nor `net.Error`. `unreachable()` correctly treats it as answered rather than skipping it, but the retry loop's only fast exit checks `IsUnauthorized`, so a bad cert burns the full ~31s backoff before the build fails, the same latency #420 removed for other cases.

## Change
Add `certRejected`, matching `*tls.CertificateVerificationError`, and short-circuit the retry loop on it alongside `IsUnauthorized`.

## Test
`TestCertRejected` exercises the real error `http.Client` produces against an untrusted cert. `registry.NewService` treats `127.0.0.0/8` as insecure by default and skips cert verification there, so this can't be reproduced through `Verify()` with a local listener; `certRejected` is tested directly instead.