### PR TITLE
PLAT-9571: lazy AWS config load so ECR auth survives slow networking

### DIFF
--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -59,7 +59,7 @@ func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Regis
 	// Pod networking may not be up yet (istio ambient, DOM-70981). Registering
 	// unconditionally lets authenticate finish the load on the first build.
 	if err := loadConfig(ctx, logger); err != nil {
-		logger.Info("ECR registered, AWS config load deferred", "error", err)
+		logger.Info("ECR registered, AWS config load deferred to first use", "error", err)
 		return nil
 	}
 

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -40,9 +41,12 @@ func (l awsLogger) Logf(classification logging.Classification, format string, v 
 }
 
 var (
-	awsConfig aws.Config
-	newClient = newECRClient
-	urlRegex  = regexp.MustCompile(
+	awsConfig    aws.Config
+	awsConfigMu  sync.Mutex
+	awsConfigSet bool
+	loadDefault  = config.LoadDefaultConfig
+	newClient    = newECRClient
+	urlRegex     = regexp.MustCompile(
 		//nolint:lll
 		`^(?P<aws_account_id>[a-zA-Z\d][a-zA-Z\d-_]*)\.dkr\.ecr(-fips)?\.(?P<region>[a-zA-Z\d][a-zA-Z\d-_]*)\.amazonaws\.com(\.cn)?`,
 	)
@@ -50,11 +54,31 @@ var (
 )
 
 func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Registry) error {
+	registry.Register(urlRegex, authenticate)
+
+	// Pod networking may not be up yet (istio ambient, DOM-70981). Registering
+	// unconditionally lets authenticate finish the load on the first build.
+	if err := loadConfig(ctx, logger); err != nil {
+		logger.Info("ECR registered, AWS config load deferred", "error", err)
+		return nil
+	}
+
+	logger.Info("ECR registered")
+	return nil
+}
+
+func loadConfig(ctx context.Context, logger logr.Logger) error {
+	awsConfigMu.Lock()
+	defer awsConfigMu.Unlock()
+
+	if awsConfigSet {
+		return nil
+	}
+
 	clientMode := aws.LogRequest | aws.LogResponse | aws.LogRetries
 	clientLogger := &awsLogger{logger}
 
-	var err error
-	awsConfig, err = config.LoadDefaultConfig(
+	cfg, err := loadDefault(
 		ctx,
 		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
 			o.Client = imds.New(imds.Options{
@@ -66,19 +90,22 @@ func Register(ctx context.Context, logger logr.Logger, registry *cloudauth.Regis
 		config.WithClientLogMode(clientMode),
 	)
 	if err != nil {
-		logger.Info("ECR not registered", "error", err)
-		return nil
+		return err
 	}
 
-	registry.Register(urlRegex, authenticate)
-	logger.Info("ECR registered")
+	awsConfig = cfg
+	awsConfigSet = true
 	return nil
 }
 
-func newECRClient(region string) ecrClient {
+func newECRClient(ctx context.Context, logger logr.Logger, region string) (ecrClient, error) {
+	if err := loadConfig(ctx, logger); err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
 	c := awsConfig
 	c.Region = region
-	return ecr.NewFromConfig(c)
+	return ecr.NewFromConfig(c), nil
 }
 
 func authenticate(ctx context.Context, logger logr.Logger, url string) (*registry.AuthConfig, error) {
@@ -91,7 +118,11 @@ func authenticate(ctx context.Context, logger logr.Logger, url string) (*registr
 		return nil, err
 	}
 
-	client := newClient(match[urlRegexRegionIndex])
+	client, err := newClient(ctx, logger, match[urlRegexRegionIndex])
+	if err != nil {
+		logger.Info(err.Error())
+		return nil, err
+	}
 	input := &ecr.GetAuthorizationTokenInput{}
 
 	resp, err := client.GetAuthorizationToken(ctx, input)

--- a/pkg/controller/support/credentials/cloudauth/ecr/ecr_test.go
+++ b/pkg/controller/support/credentials/cloudauth/ecr/ecr_test.go
@@ -7,9 +7,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/docker/docker/api/types/registry"
+	"github.com/dominodatalab/hephaestus/pkg/controller/support/credentials/cloudauth"
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -154,9 +158,9 @@ func TestAuthenticate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			newClient = func(region string) ecrClient {
+			newClient = func(_ context.Context, _ logr.Logger, region string) (ecrClient, error) {
 				tt.client.region = region
-				return &tt.client
+				return &tt.client, nil
 			}
 			authConfig, err := authenticate(defaultCtx, log, tt.serverUrl)
 
@@ -198,4 +202,22 @@ func (f *fakeECRClient) GetAuthorizationToken(
 		return nil, errors.New("test error")
 	}
 	return f.TokenOutput, nil
+}
+
+func TestRegisterDefersConfigLoad(t *testing.T) {
+	newClient = newECRClient
+	loadErr := errors.New("imds unreachable")
+	loadDefault = func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{}, loadErr
+	}
+	t.Cleanup(func() { loadDefault = config.LoadDefaultConfig })
+
+	ctx := context.Background()
+	log := zapr.NewLogger(zap.NewNop())
+	reg := &cloudauth.Registry{}
+	require.NoError(t, Register(ctx, log, reg))
+	assert.False(t, awsConfigSet)
+
+	_, err := reg.RetrieveAuthorization(ctx, log, "0123456789012.dkr.ecr.us-east-1.amazonaws.com")
+	assert.ErrorIs(t, err, loadErr)
 }


### PR DESCRIPTION
Jira: https://dominodatalab.atlassian.net/browse/PLAT-9571

`ecr.Register` called `config.LoadDefaultConfig` once at startup and on failure skipped registering the loader. Under istio ambient the pod has no routable network for its first seconds (DOM-70981), IMDS times out at 5s, and ECR auth is gone until the pod restarts.

The loader is now registered unconditionally and the AWS config loads lazily, memoized on success. A failed startup load surfaces as an error from `authenticate`, which `RefreshingAuthProvider` already retries per build.

Behavior change only when the load fails: a build that references a private ECR host with no static secret on a non AWS cluster now fails after the provider's retries instead of instantly, and logs the load error.
